### PR TITLE
feat: grid-based asset picker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Instructions
+
+- Do not add new binary assets (e.g., `.glb`, images, archives). Only use the 3D models and media already present in this repository.
+- Prefer updating HTML and documentation files (such as `index.html` and `README.md`) when adjusting the UI or messaging.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Bootstrap Avatar Preview
 
-A minimal avatar editor using [Three.js](https://threejs.org/) and [Bootstrap 5](https://getbootstrap.com/).
+A static avatar editor mock-up inspired by modern hero-customizer UIs, powered by [Three.js](https://threejs.org/) and [Bootstrap 5](https://getbootstrap.com/).
 
-The page loads the `Armature.glb` avatar and shows a grid of asset cards. Each card toggles an extra model; for now they all reuse the bundled `Teleporter Base.glb` so no additional binaries are required. A narrow sidebar holds category icons, and clicking a card loads or removes the asset. A simple color picker changes the avatar's material color. Models are compressed with [Draco](https://google.github.io/draco/), and the decoder is fetched from the Three.js CDN at runtime so no build step is required.
+The page loads the bundled `Armature.glb` avatar beside a glossy asset browser. A blurred icon rail anchors the layout, while the left panel presents outfit cards that toggle optional models — for now every card reuses the existing `Teleporter Base.glb` so no extra binaries are needed. A floating color chip lets you tint the avatar, and the scene lighting/gradient backdrop match the polished concept art reference.
+
+Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, so everything continues to work in a simple static environment.
 
 ## Run locally
 1. Install a static server such as [`live-server`](https://www.npmjs.com/package/live-server).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# React Three Fiber Ultimate Character Configurator
+# Bootstrap Avatar Preview
 
-Final repository
+A minimal avatar editor using [Three.js](https://threejs.org/) and [Bootstrap 5](https://getbootstrap.com/).
 
-![Video thumbnail](http://img.youtube.com/vi/yA4BpGqT3-s/maxresdefault.jpg?w)
+The page loads the `Armature.glb` avatar and shows a grid of asset cards. Each card toggles an extra model; for now they all reuse the bundled `Teleporter Base.glb` so no additional binaries are required. A narrow sidebar holds category icons, and clicking a card loads or removes the asset. A simple color picker changes the avatar's material color. Models are compressed with [Draco](https://google.github.io/draco/), and the decoder is fetched from the Three.js CDN at runtime so no build step is required.
 
-[Video tutorial](https://youtu.be/yA4BpGqT3-s)
+## Run locally
+1. Install a static server such as [`live-server`](https://www.npmjs.com/package/live-server).
+   ```bash
+   npm install -g live-server
+   ```
+2. From the repository root, start the server:
+   ```bash
+   live-server
+   ```
+3. Navigate to the address printed by the server (usually http://127.0.0.1:8080).
 
+The page uses vanilla ES modules resolved via an import map to CDNs, so no build step is required.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A static avatar editor mock-up that mirrors the provided concept art while stayi
 
 ## Highlights
 - **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
-- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that streams the existing `Assets/NakedFullBody.glb` model directly from `Assets.zip`, alongside wardrobe categories (cape, gauntlets, boots, pose pack) that reuse the bundled Teleporter Base and Poses assets—no new binaries required.
-- **Responsive color tooling:** The viewer keeps the hero rig in frame while extras toggle around it, and the floating “Primary Color” control recolors the avatar in real time.
+- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that composites the existing `Assets/NakedFullBody.glb` body with the head, face, eyes, brow, and nose pieces stored in `Assets.zip`, while the other categories (cape, gauntlets, boots, pose pack) continue to reuse the bundled Teleporter Base and Poses assets—no new binaries required.
+- **Steady color tooling:** The viewer now holds a static hero pose without auto-rotation, keeps the rig framed while extras toggle around it, and the floating “Primary Color” control tints the assembled body pieces together in real time.
 
 Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, and the hero mesh is unpacked in-browser with JSZip so everything continues to work in a simple static environment.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Bootstrap Avatar Preview
 
-A static avatar editor mock-up inspired by modern hero-customizer UIs, powered by [Three.js](https://threejs.org/) and [Bootstrap 5](https://getbootstrap.com/).
+A static avatar editor mock-up that mirrors the provided concept art while staying completely portable thanks to [Three.js](https://threejs.org/) and [Bootstrap 5](https://getbootstrap.com/).
 
-The page loads the bundled `Armature.glb` avatar beside a glossy asset browser. A blurred icon rail anchors the layout, while the left panel presents outfit cards that toggle optional models — for now every card reuses the existing `Teleporter Base.glb` so no extra binaries are needed. A floating color chip lets you tint the avatar, and the scene lighting/gradient backdrop match the polished concept art reference.
+## Highlights
+- **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
+- **Stylized library cards:** The outfit library is arranged as a soft, rounded grid with “SENSEI” watermarks and gradient swatches. Each entry still toggles the bundled `Teleporter Base.glb`, so the demo avoids introducing any new binary assets.
+- **Responsive color tooling:** The avatar preview loads `Armature.glb` by default, keeps rotating inside the neon frame, and exposes a floating “Primary Color” control for quick palette tweaks.
 
 Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, so everything continues to work in a simple static environment.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,28 @@ A static avatar editor mock-up that mirrors the provided concept art while stayi
 
 ## Highlights
 - **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
-- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that composites the existing `Assets/NakedFullBody.glb` body with the head, face, eyes, brow, and nose pieces stored in `Assets.zip`, while every optional item swaps in its own GLB—Hair.010, WawaDress, Hat.001 for the crown, Hat.007 for bunny ears, Shoes.002, and the Teleporter Base—so the previewer shows the real wardrobe set instead of repeated placeholders.
+- **Wardrobe lineup:** The selector now boots from `assets-manifest.json`, keeping the pinned "Hero Body Suit" card while automatically listing every GLB inside `Assets.zip` alongside the Teleporter Base so the previewer exposes the real wardrobe set instead of repeated placeholders.
 - **Thumbnail fidelity:** Card art is streamed straight out of `Assets.zip` (hair.jpg, shoes.jpg, thumbnail_wawadress.png, thumbnail_crown.png, etc.), giving each selector tile an accurate snapshot of the asset it toggles.
+- **Manifest driven:** Cards, source paths, and lock states are read from `assets-manifest.json`, so exposing new wardrobe pieces only requires editing data instead of hand-writing HTML tiles.
 - **Relaxed poses:** Selecting the "Relaxed Idle" pose card loads `public/models/Poses.glb` once and applies the Idle animation clip to the assembled body and clothing, delivering the chilled stance requested while keeping everything on the existing skeleton.
 - **Steady color tooling:** The viewer stays static, reframes automatically as items change, and the floating “Primary Color” control still tints the assembled body pieces together in real time.
+
+## Asset manifest
+The wardrobe selector fetches `assets-manifest.json` at startup and builds cards from its entries:
+
+```json
+{
+  "id": "wardrobe-hair",
+  "type": "extra",
+  "title": "Layered Hair 10",
+  "source": { "zip": "Assets.zip", "entry": "Assets/Hair.010.glb" },
+  "thumbnail": { "zip": "Assets.zip", "entry": "Assets/hair.jpg" },
+  "labels": { "active": "Equipped", "inactive": "Tap to equip" }
+}
+```
+
+- Entries describing core attachments are flagged with `"type": "attachment"` and `"locked": true` so they surface in the UI but stay pinned to the hero mesh that already loads them.
+- Append new objects to the array to expose more GLBs from `Assets.zip`; the viewer will generate cards, hook up toggles, and stream the geometry without touching `index.html`.
 
 Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, and the hero mesh is unpacked in-browser with JSZip so everything continues to work in a simple static environment.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A static avatar editor mock-up that mirrors the provided concept art while stayi
 
 ## Highlights
 - **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
-- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that loads `Armature.glb` and reorganized wardrobe categories (cape, gauntlets, boots, pose pack) that reuse the existing Teleporter Base and Poses assets—no new binaries required.
+- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that streams the existing `Assets/NakedFullBody.glb` model directly from `Assets.zip`, alongside wardrobe categories (cape, gauntlets, boots, pose pack) that reuse the bundled Teleporter Base and Poses assets—no new binaries required.
 - **Responsive color tooling:** The viewer keeps the hero rig in frame while extras toggle around it, and the floating “Primary Color” control recolors the avatar in real time.
 
-Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, so everything continues to work in a simple static environment.
+Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, and the hero mesh is unpacked in-browser with JSZip so everything continues to work in a simple static environment.
 
 ## Run locally
 1. Install a static server such as [`live-server`](https://www.npmjs.com/package/live-server).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A static avatar editor mock-up that mirrors the provided concept art while stayi
 
 ## Highlights
 - **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
-- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that composites the existing `Assets/NakedFullBody.glb` body with the head, face, eyes, brow, and nose pieces stored in `Assets.zip`, while every optional item swaps in its own GLB—Hair.010, WawaDress, Hat.006/007, Shoes.002, and the Teleporter Base—so the previewer shows the real wardrobe set instead of repeated placeholders.
+- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that composites the existing `Assets/NakedFullBody.glb` body with the head, face, eyes, brow, and nose pieces stored in `Assets.zip`, while every optional item swaps in its own GLB—Hair.010, WawaDress, Hat.001 for the crown, Hat.007 for bunny ears, Shoes.002, and the Teleporter Base—so the previewer shows the real wardrobe set instead of repeated placeholders.
 - **Thumbnail fidelity:** Card art is streamed straight out of `Assets.zip` (hair.jpg, shoes.jpg, thumbnail_wawadress.png, thumbnail_crown.png, etc.), giving each selector tile an accurate snapshot of the asset it toggles.
 - **Relaxed poses:** Selecting the "Relaxed Idle" pose card loads `public/models/Poses.glb` once and applies the Idle animation clip to the assembled body and clothing, delivering the chilled stance requested while keeping everything on the existing skeleton.
 - **Steady color tooling:** The viewer stays static, reframes automatically as items change, and the floating “Primary Color” control still tints the assembled body pieces together in real time.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A static avatar editor mock-up that mirrors the provided concept art while stayi
 
 ## Highlights
 - **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
-- **Stylized library cards:** The outfit library is arranged as a soft, rounded grid with “SENSEI” watermarks and gradient swatches. Each entry still toggles the bundled `Teleporter Base.glb`, so the demo avoids introducing any new binary assets.
-- **Responsive color tooling:** The avatar preview loads `Armature.glb` by default, keeps rotating inside the neon frame, and exposes a floating “Primary Color” control for quick palette tweaks.
+- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that loads `Armature.glb` and reorganized wardrobe categories (cape, gauntlets, boots, pose pack) that reuse the existing Teleporter Base and Poses assets—no new binaries required.
+- **Responsive color tooling:** The viewer keeps the hero rig in frame while extras toggle around it, and the floating “Primary Color” control recolors the avatar in real time.
 
 Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, so everything continues to work in a simple static environment.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ A static avatar editor mock-up that mirrors the provided concept art while stayi
 
 ## Highlights
 - **Gradient shell:** A deep violet backdrop, blurred icon rail, and glowing viewer pane reproduce the two-panel hero layout from the reference.
-- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that composites the existing `Assets/NakedFullBody.glb` body with the head, face, eyes, brow, and nose pieces stored in `Assets.zip`, while the other categories (cape, gauntlets, boots, pose pack) continue to reuse the bundled Teleporter Base and Poses assets—no new binaries required.
-- **Steady color tooling:** The viewer now holds a static hero pose without auto-rotation, keeps the rig framed while extras toggle around it, and the floating “Primary Color” control tints the assembled body pieces together in real time.
+- **Wardrobe lineup:** The grid now opens with a pinned "Hero Body Suit" card that composites the existing `Assets/NakedFullBody.glb` body with the head, face, eyes, brow, and nose pieces stored in `Assets.zip`, while every optional item swaps in its own GLB—Hair.010, WawaDress, Hat.006/007, Shoes.002, and the Teleporter Base—so the previewer shows the real wardrobe set instead of repeated placeholders.
+- **Thumbnail fidelity:** Card art is streamed straight out of `Assets.zip` (hair.jpg, shoes.jpg, thumbnail_wawadress.png, thumbnail_crown.png, etc.), giving each selector tile an accurate snapshot of the asset it toggles.
+- **Relaxed poses:** Selecting the "Relaxed Idle" pose card loads `public/models/Poses.glb` once and applies the Idle animation clip to the assembled body and clothing, delivering the chilled stance requested while keeping everything on the existing skeleton.
+- **Steady color tooling:** The viewer stays static, reframes automatically as items change, and the floating “Primary Color” control still tints the assembled body pieces together in real time.
 
 Models remain Draco-compressed with the decoder fetched from the Three.js CDN at runtime, and the hero mesh is unpacked in-browser with JSZip so everything continues to work in a simple static environment.
 

--- a/assets-manifest.json
+++ b/assets-manifest.json
@@ -1,0 +1,2421 @@
+[
+  {
+    "id": "core-hero",
+    "type": "avatar",
+    "title": "Hero Body Suit",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Base Layer",
+    "description": "Streams the bundled NakedFullBody mesh and facial attachments from Assets.zip.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/NakedFullBody.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": true,
+    "labels": {
+      "active": "Pinned in scene",
+      "inactive": "Pinned in scene"
+    },
+    "icons": {
+      "active": "bi-pin-angle-fill",
+      "inactive": "bi-pin-angle-fill"
+    },
+    "selected": true
+  },
+  {
+    "id": "bow-001",
+    "type": "extra",
+    "title": "Bow 1",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Props",
+    "description": "Loads the bow asset from Assets/Bow.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Bow.001.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "bow-002",
+    "type": "extra",
+    "title": "Bow 2",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Props",
+    "description": "Loads the bow asset from Assets/Bow.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Bow.002.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "wardrobe-bunny",
+    "type": "extra",
+    "title": "Bunny Ears",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Swaps in the playful bunny ear headpiece bundled as Hat.007.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.007.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/thumbnail_bunny.png"
+    },
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    }
+  },
+  {
+    "id": "wardrobe-crown",
+    "type": "extra",
+    "title": "Crown Halo",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Adds the golden crown from Assets/Hat.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/thumbnail_crown.png"
+    },
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    }
+  },
+  {
+    "id": "earring-001",
+    "type": "extra",
+    "title": "Earring 1",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Jewelry",
+    "description": "Loads the earring asset from Assets/Earring.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Earring.001.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "earring-002",
+    "type": "extra",
+    "title": "Earring 2",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Jewelry",
+    "description": "Loads the earring asset from Assets/Earring.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Earring.002.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "earring-003",
+    "type": "extra",
+    "title": "Earring 3",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Jewelry",
+    "description": "Loads the earring asset from Assets/Earring.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Earring.003.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "earring-004",
+    "type": "extra",
+    "title": "Earring 4",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Jewelry",
+    "description": "Loads the earring asset from Assets/Earring.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Earring.004.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "earring-005",
+    "type": "extra",
+    "title": "Earring 5",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Jewelry",
+    "description": "Loads the earring asset from Assets/Earring.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Earring.005.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "earring-006",
+    "type": "extra",
+    "title": "Earring 6",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Jewelry",
+    "description": "Loads the earring asset from Assets/Earring.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Earring.006.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facemask",
+    "type": "extra",
+    "title": "Face Mask",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Face",
+    "description": "Loads the face mask asset from Assets/FaceMask.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FaceMask.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-001",
+    "type": "extra",
+    "title": "Facial Hair 1",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.001.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-002",
+    "type": "extra",
+    "title": "Facial Hair 2",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.002.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-003",
+    "type": "extra",
+    "title": "Facial Hair 3",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.003.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-004",
+    "type": "extra",
+    "title": "Facial Hair 4",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.004.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-005",
+    "type": "extra",
+    "title": "Facial Hair 5",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.005.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-006",
+    "type": "extra",
+    "title": "Facial Hair 6",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.006.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "facialhair-007",
+    "type": "extra",
+    "title": "Facial Hair 7",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Facial Hair",
+    "description": "Loads the facial hair asset from Assets/FacialHair.007.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/FacialHair.007.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "glasses-001",
+    "type": "extra",
+    "title": "Glasses 1",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Eyewear",
+    "description": "Loads the glasses asset from Assets/Glasses.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Glasses.001.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "glasses-002",
+    "type": "extra",
+    "title": "Glasses 2",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Eyewear",
+    "description": "Loads the glasses asset from Assets/Glasses.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Glasses.002.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "glasses-003",
+    "type": "extra",
+    "title": "Glasses 3",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Eyewear",
+    "description": "Loads the glasses asset from Assets/Glasses.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Glasses.003.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "glasses-004",
+    "type": "extra",
+    "title": "Glasses 4",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Eyewear",
+    "description": "Loads the glasses asset from Assets/Glasses.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Glasses.004.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hat-002",
+    "type": "extra",
+    "title": "Hat 2",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Loads the hat asset from Assets/Hat.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.002.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hat-003",
+    "type": "extra",
+    "title": "Hat 3",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Loads the hat asset from Assets/Hat.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.003.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hat-004",
+    "type": "extra",
+    "title": "Hat 4",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Loads the hat asset from Assets/Hat.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.004.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hat-005",
+    "type": "extra",
+    "title": "Hat 5",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Loads the hat asset from Assets/Hat.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.005.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hat-006",
+    "type": "extra",
+    "title": "Hat 6",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Headwear",
+    "description": "Loads the hat asset from Assets/Hat.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hat.006.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "pumpkinhead",
+    "type": "extra",
+    "title": "Pumpkin Head",
+    "badge": "Accessory",
+    "eyebrow": "Accessories · Seasonal",
+    "description": "Loads the pumpkin head asset from Assets/PumpkinHead.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/PumpkinHead.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "armature",
+    "type": "extra",
+    "title": "Armature",
+    "badge": "Avatar",
+    "eyebrow": "Avatar · Rig",
+    "description": "Loads the armature asset from Assets/Armature.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Armature.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "avatar-armature",
+    "type": "avatar",
+    "title": "Armature Rig",
+    "badge": "Avatar",
+    "eyebrow": "Avatar · Rig",
+    "description": "Loads the Armature.glb rig from the public models.",
+    "source": {
+      "url": "public/models/Armature.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "labels": {
+      "active": "Loaded",
+      "inactive": "Tap to load"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    }
+  },
+  {
+    "id": "eyebrow-001",
+    "type": "attachment",
+    "title": "Eye Brow 1",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": true,
+    "labels": {
+      "active": "Bundled with hero",
+      "inactive": "Bundled with hero"
+    },
+    "icons": {
+      "active": "bi-pin-angle-fill",
+      "inactive": "bi-pin-angle-fill"
+    },
+    "selected": true
+  },
+  {
+    "id": "eyebrow-010",
+    "type": "extra",
+    "title": "Eye Brow 10",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.010.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.010.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-002",
+    "type": "extra",
+    "title": "Eye Brow 2",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-003",
+    "type": "extra",
+    "title": "Eye Brow 3",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-004",
+    "type": "extra",
+    "title": "Eye Brow 4",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.004.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-005",
+    "type": "extra",
+    "title": "Eye Brow 5",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.005.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-006",
+    "type": "extra",
+    "title": "Eye Brow 6",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.006.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-007",
+    "type": "extra",
+    "title": "Eye Brow 7",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.007.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.007.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-008",
+    "type": "extra",
+    "title": "Eye Brow 8",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.008.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.008.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyebrow-009",
+    "type": "extra",
+    "title": "Eye Brow 9",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Brow Variants",
+    "description": "Loads the eye brow asset from Assets/EyeBrow.009.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/EyeBrow.009.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/eyebrows.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-001",
+    "type": "attachment",
+    "title": "Eyes 1",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": true,
+    "labels": {
+      "active": "Bundled with hero",
+      "inactive": "Bundled with hero"
+    },
+    "icons": {
+      "active": "bi-pin-angle-fill",
+      "inactive": "bi-pin-angle-fill"
+    },
+    "selected": true
+  },
+  {
+    "id": "eyes-010",
+    "type": "extra",
+    "title": "Eyes 10",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.010.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.010.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-011",
+    "type": "extra",
+    "title": "Eyes 11",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.011.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.011.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-012",
+    "type": "extra",
+    "title": "Eyes 12",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.012.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.012.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-002",
+    "type": "extra",
+    "title": "Eyes 2",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-003",
+    "type": "extra",
+    "title": "Eyes 3",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-004",
+    "type": "extra",
+    "title": "Eyes 4",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.004.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-005",
+    "type": "extra",
+    "title": "Eyes 5",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.005.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-006",
+    "type": "extra",
+    "title": "Eyes 6",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.006.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-007",
+    "type": "extra",
+    "title": "Eyes 7",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.007.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.007.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-008",
+    "type": "extra",
+    "title": "Eyes 8",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.008.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.008.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "eyes-009",
+    "type": "extra",
+    "title": "Eyes 9",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Eye Variants",
+    "description": "Loads the eyes asset from Assets/Eyes.009.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Eyes.009.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "face-001",
+    "type": "attachment",
+    "title": "Face 1",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": true,
+    "labels": {
+      "active": "Bundled with hero",
+      "inactive": "Bundled with hero"
+    },
+    "icons": {
+      "active": "bi-pin-angle-fill",
+      "inactive": "bi-pin-angle-fill"
+    },
+    "selected": true
+  },
+  {
+    "id": "face-002",
+    "type": "extra",
+    "title": "Face 2",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "face-003",
+    "type": "extra",
+    "title": "Face 3",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "face-004",
+    "type": "extra",
+    "title": "Face 4",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.004.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "face-005",
+    "type": "extra",
+    "title": "Face 5",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.005.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "face-006",
+    "type": "extra",
+    "title": "Face 6",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.006.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "face-007",
+    "type": "extra",
+    "title": "Face 7",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Face Variants",
+    "description": "Loads the face asset from Assets/Face.007.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Face.007.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "head-001",
+    "type": "attachment",
+    "title": "Head 1",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Head Variants",
+    "description": "Loads the head asset from Assets/Head.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Head.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": true,
+    "labels": {
+      "active": "Bundled with hero",
+      "inactive": "Bundled with hero"
+    },
+    "icons": {
+      "active": "bi-pin-angle-fill",
+      "inactive": "bi-pin-angle-fill"
+    },
+    "selected": true
+  },
+  {
+    "id": "head-002",
+    "type": "extra",
+    "title": "Head 2",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Head Variants",
+    "description": "Loads the head asset from Assets/Head.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Head.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "head-003",
+    "type": "extra",
+    "title": "Head 3",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Head Variants",
+    "description": "Loads the head asset from Assets/Head.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Head.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "head-004",
+    "type": "extra",
+    "title": "Head 4",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Head Variants",
+    "description": "Loads the head asset from Assets/Head.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Head.004.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/head.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "nose-001",
+    "type": "attachment",
+    "title": "Nose 1",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Nose Variants",
+    "description": "Loads the nose asset from Assets/Nose.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Nose.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/nose.jpg"
+    },
+    "locked": true,
+    "labels": {
+      "active": "Bundled with hero",
+      "inactive": "Bundled with hero"
+    },
+    "icons": {
+      "active": "bi-pin-angle-fill",
+      "inactive": "bi-pin-angle-fill"
+    },
+    "selected": true
+  },
+  {
+    "id": "nose-002",
+    "type": "extra",
+    "title": "Nose 2",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Nose Variants",
+    "description": "Loads the nose asset from Assets/Nose.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Nose.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/nose.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "nose-003",
+    "type": "extra",
+    "title": "Nose 3",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Nose Variants",
+    "description": "Loads the nose asset from Assets/Nose.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Nose.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/nose.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "nose-004",
+    "type": "extra",
+    "title": "Nose 4",
+    "badge": "Core",
+    "eyebrow": "Wardrobe · Nose Variants",
+    "description": "Loads the nose asset from Assets/Nose.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Nose.004.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/nose.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "pose-idle",
+    "type": "pose",
+    "title": "Relaxed Idle",
+    "badge": "Pose",
+    "eyebrow": "Animation · Pose",
+    "description": "Applies the Idle clip from the bundled Poses.glb for a relaxed stance.",
+    "pose": "Idle",
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "labels": {
+      "active": "Applied",
+      "inactive": "Tap to apply"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    }
+  },
+  {
+    "id": "platform-teleporter",
+    "type": "extra",
+    "title": "Teleporter Base",
+    "badge": "Scene",
+    "eyebrow": "Environment · Platform",
+    "description": "Supplied pedestal from the original scene kit.",
+    "source": {
+      "url": "public/models/Teleporter Base.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": true
+  },
+  {
+    "id": "bottom-001",
+    "type": "extra",
+    "title": "Bottom 1",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Bottoms",
+    "description": "Loads the bottom asset from Assets/Bottom.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Bottom.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/bottom.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "bottom-002",
+    "type": "extra",
+    "title": "Bottom 2",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Bottoms",
+    "description": "Loads the bottom asset from Assets/Bottom.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Bottom.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/bottom.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "bottom-003",
+    "type": "extra",
+    "title": "Bottom 3",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Bottoms",
+    "description": "Loads the bottom asset from Assets/Bottom.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Bottom.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/bottom.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-001",
+    "type": "extra",
+    "title": "Hair 1",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-011",
+    "type": "extra",
+    "title": "Hair 11",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.011.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.011.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-002",
+    "type": "extra",
+    "title": "Hair 2",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-003",
+    "type": "extra",
+    "title": "Hair 3",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-004",
+    "type": "extra",
+    "title": "Hair 4",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.004.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-005",
+    "type": "extra",
+    "title": "Hair 5",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.005.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.005.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-006",
+    "type": "extra",
+    "title": "Hair 6",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.006.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.006.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-007",
+    "type": "extra",
+    "title": "Hair 7",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.007.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.007.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-008",
+    "type": "extra",
+    "title": "Hair 8",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.008.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.008.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "hair-009",
+    "type": "extra",
+    "title": "Hair 9",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads the hair asset from Assets/Hair.009.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.009.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "wardrobe-hair",
+    "type": "extra",
+    "title": "Layered Hair 10",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Hair",
+    "description": "Loads Hair.010.glb directly from Assets.zip.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Hair.010.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/hair.jpg"
+    },
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": true
+  },
+  {
+    "id": "outfit-001",
+    "type": "extra",
+    "title": "Outfit 1",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Full Outfits",
+    "description": "Loads the outfit asset from Assets/Outfit.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Outfit.001.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "outfit-002",
+    "type": "extra",
+    "title": "Outfit 2",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Full Outfits",
+    "description": "Loads the outfit asset from Assets/Outfit.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Outfit.002.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "outfit-003",
+    "type": "extra",
+    "title": "Outfit 3",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Full Outfits",
+    "description": "Loads the outfit asset from Assets/Outfit.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Outfit.003.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "outfit-004",
+    "type": "extra",
+    "title": "Outfit 4",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Full Outfits",
+    "description": "Loads the outfit asset from Assets/Outfit.004.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Outfit.004.glb"
+    },
+    "thumbnail": {
+      "url": "public/images/wawasensei-white.png"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "shoes-001",
+    "type": "extra",
+    "title": "Shoes 1",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Footwear",
+    "description": "Loads the shoes asset from Assets/Shoes.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Shoes.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/shoes.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "shoes-003",
+    "type": "extra",
+    "title": "Shoes 3",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Footwear",
+    "description": "Loads the shoes asset from Assets/Shoes.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Shoes.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/shoes.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "wardrobe-shoes",
+    "type": "extra",
+    "title": "Strider Boots 2",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Footwear",
+    "description": "Loads the stylised boot geometry from Assets/Shoes.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Shoes.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/shoes.jpg"
+    },
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": true
+  },
+  {
+    "id": "top-001",
+    "type": "extra",
+    "title": "Top 1",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Tops",
+    "description": "Loads the top asset from Assets/Top.001.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Top.001.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/top.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "top-002",
+    "type": "extra",
+    "title": "Top 2",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Tops",
+    "description": "Loads the top asset from Assets/Top.002.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Top.002.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/top.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "top-003",
+    "type": "extra",
+    "title": "Top 3",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Tops",
+    "description": "Loads the top asset from Assets/Top.003.glb.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/Top.003.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/top.jpg"
+    },
+    "locked": false,
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": false
+  },
+  {
+    "id": "wardrobe-dress",
+    "type": "extra",
+    "title": "Wawa Dress",
+    "badge": "Wardrobe",
+    "eyebrow": "Wardrobe · Dresses",
+    "description": "Loads the stylised WawaDress.glb from the asset pack.",
+    "source": {
+      "zip": "Assets.zip",
+      "entry": "Assets/WawaDress.glb"
+    },
+    "thumbnail": {
+      "zip": "Assets.zip",
+      "entry": "Assets/thumbnail_wawadress.png"
+    },
+    "labels": {
+      "active": "Equipped",
+      "inactive": "Tap to equip"
+    },
+    "icons": {
+      "active": "bi-check2-circle",
+      "inactive": "bi-plus-circle"
+    },
+    "selected": true
+  }
+]

--- a/index.html
+++ b/index.html
@@ -518,248 +518,8 @@
           <button type="button" class="btn btn-tab">Extras</button>
         </div>
 
-        <div id="assetGrid" class="asset-grid" role="list">
-          <div
-            class="asset-card selected locked"
-            data-id="core-hero"
-            data-type="avatar"
-            data-locked="true"
-            data-zip="Assets.zip"
-            data-entry="Assets/NakedFullBody.glb"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/head.jpg"
-            data-label-active="Pinned in scene"
-            data-label-inactive="Pinned in scene"
-            data-icon-active="bi-pin-angle-fill"
-            data-icon-inactive="bi-pin-angle-fill"
-            role="listitem"
-            aria-pressed="true"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Core</span>
-              <img src="public/images/wawasensei-white.png" alt="Hero body thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Base Layer</span>
-              <h2 class="card-title">Hero Body Suit</h2>
-              <p class="card-text">Streams the bundled NakedFullBody mesh together with the matching facial pieces from Assets.zip.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
-              <span>Pinned in scene</span>
-            </div>
-          </div>
-          <div
-            class="asset-card selected"
-            data-id="platform-teleporter"
-            data-url="public/models/Teleporter Base.glb"
-            data-thumb="public/images/wawasensei-white.png"
-            data-label-active="Equipped"
-            data-label-inactive="Tap to equip"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="true"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Scene</span>
-              <img src="public/images/wawasensei-white.png" alt="Teleporter base thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Environment · Platform</span>
-              <h2 class="card-title">Teleporter Base</h2>
-              <p class="card-text">Supplied pedestal from the original scene kit.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-check2-circle" aria-hidden="true"></i>
-              <span>Equipped</span>
-            </div>
-          </div>
-          <div
-            class="asset-card selected"
-            data-id="wardrobe-hair"
-            data-zip="Assets.zip"
-            data-entry="Assets/Hair.010.glb"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/hair.jpg"
-            data-label-active="Equipped"
-            data-label-inactive="Tap to equip"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="true"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Wardrobe</span>
-              <img src="public/images/wawasensei-white.png" alt="Hair layer thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Hair</span>
-              <h2 class="card-title">Layered Hair</h2>
-              <p class="card-text">Loads Hair.010.glb directly from Assets.zip to frame the hero with the bundled style.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-check2-circle" aria-hidden="true"></i>
-              <span>Equipped</span>
-            </div>
-          </div>
-          <div
-            class="asset-card selected"
-            data-id="wardrobe-dress"
-            data-zip="Assets.zip"
-            data-entry="Assets/WawaDress.glb"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/thumbnail_wawadress.png"
-            data-label-active="Equipped"
-            data-label-inactive="Tap to equip"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="true"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Wardrobe</span>
-              <img src="public/images/wawasensei-white.png" alt="Dress thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Outfit</span>
-              <h2 class="card-title">Wawa Dress</h2>
-              <p class="card-text">Streams the Draco-compressed WawaDress.glb from Assets.zip for a full-length outfit.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-check2-circle" aria-hidden="true"></i>
-              <span>Equipped</span>
-            </div>
-          </div>
-          <div
-            class="asset-card"
-            data-id="wardrobe-crown"
-            data-zip="Assets.zip"
-            data-entry="Assets/Hat.001.glb"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/thumbnail_crown.png"
-            data-label-active="Equipped"
-            data-label-inactive="Tap to equip"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="false"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Accessory</span>
-              <img src="public/images/wawasensei-white.png" alt="Crown accessory thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Accessories · Head</span>
-              <h2 class="card-title">Crown Halo</h2>
-              <p class="card-text">Adds the golden crown from Assets/Hat.001.glb for a regal accent.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-plus-circle" aria-hidden="true"></i>
-              <span>Tap to equip</span>
-            </div>
-          </div>
-          <div
-            class="asset-card"
-            data-id="wardrobe-bunny"
-            data-zip="Assets.zip"
-            data-entry="Assets/Hat.007.glb"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/thumbnail_bunny.png"
-            data-label-active="Equipped"
-            data-label-inactive="Tap to equip"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="false"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Accessory</span>
-              <img src="public/images/wawasensei-white.png" alt="Bunny accessory thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Accessories · Head</span>
-              <h2 class="card-title">Bunny Ears</h2>
-              <p class="card-text">Swaps in the playful bunny ear headpiece bundled as Hat.007.glb.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-plus-circle" aria-hidden="true"></i>
-              <span>Tap to equip</span>
-            </div>
-          </div>
-          <div
-            class="asset-card"
-            data-id="wardrobe-shoes"
-            data-zip="Assets.zip"
-            data-entry="Assets/Shoes.002.glb"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/shoes.jpg"
-            data-label-active="Equipped"
-            data-label-inactive="Tap to equip"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="false"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Wardrobe</span>
-              <img src="public/images/wawasensei-white.png" alt="Shoes thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Footwear</span>
-              <h2 class="card-title">Strider Boots</h2>
-              <p class="card-text">Loads the stylised boot geometry from Assets/Shoes.002.glb.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-plus-circle" aria-hidden="true"></i>
-              <span>Tap to equip</span>
-            </div>
-          </div>
-          <div
-            class="asset-card"
-            data-id="pose-idle"
-            data-type="pose"
-            data-pose="Idle"
-            data-thumb-zip="Assets.zip"
-            data-thumb-entry="Assets/eyes.jpg"
-            data-label-active="Applied"
-            data-label-inactive="Tap to apply"
-            data-icon-active="bi-check2-circle"
-            data-icon-inactive="bi-plus-circle"
-            role="listitem"
-            aria-pressed="false"
-            tabindex="0"
-          >
-            <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Pose</span>
-              <img src="public/images/wawasensei-white.png" alt="Relaxed pose thumbnail" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Animation · Pose</span>
-              <h2 class="card-title">Relaxed Idle</h2>
-              <p class="card-text">Applies the Idle clip from the bundled Poses.glb for a relaxed stance.</p>
-            </div>
-            <div class="card-meta">
-              <i class="bi bi-plus-circle" aria-hidden="true"></i>
-              <span>Tap to apply</span>
-            </div>
-          </div>
-        </div>
+                <div id="assetGrid" class="asset-grid" role="list" aria-live="polite"></div>
+
       </section>
 
       <section class="viewer-pane">
@@ -837,65 +597,9 @@
     const extras = new Map();
     const tintTargets = new Set();
     const skinnedRoots = new Set();
-    const assetRegistry = new Map([
-      [
-        'core-hero',
-        {
-          type: 'avatar',
-          locked: true,
-          source: { zip: 'Assets.zip', entry: 'Assets/NakedFullBody.glb' },
-        },
-      ],
-      [
-        'platform-teleporter',
-        {
-          type: 'extra',
-          source: { url: 'public/models/Teleporter Base.glb' },
-        },
-      ],
-      [
-        'wardrobe-hair',
-        {
-          type: 'extra',
-          source: { zip: 'Assets.zip', entry: 'Assets/Hair.010.glb' },
-        },
-      ],
-      [
-        'wardrobe-dress',
-        {
-          type: 'extra',
-          source: { zip: 'Assets.zip', entry: 'Assets/WawaDress.glb' },
-        },
-      ],
-      [
-        'wardrobe-crown',
-        {
-          type: 'extra',
-          source: { zip: 'Assets.zip', entry: 'Assets/Hat.001.glb' },
-        },
-      ],
-      [
-        'wardrobe-bunny',
-        {
-          type: 'extra',
-          source: { zip: 'Assets.zip', entry: 'Assets/Hat.007.glb' },
-        },
-      ],
-      [
-        'wardrobe-shoes',
-        {
-          type: 'extra',
-          source: { zip: 'Assets.zip', entry: 'Assets/Shoes.002.glb' },
-        },
-      ],
-      [
-        'pose-idle',
-        {
-          type: 'pose',
-          pose: 'Idle',
-        },
-      ],
-    ]);
+    const assetRegistry = new Map();
+    const assetManifestUrl = 'assets-manifest.json';
+    let assetManifestPromise = null;
     let activePoseName = null;
     let activePoseCard = null;
     let poseClipMapPromise = null;
@@ -908,6 +612,139 @@
 
     const zipFileCache = new Map();
     const zipEntryCache = new Map();
+    function createAssetCard(entry) {
+      if (!entry || !entry.id) {
+        return null;
+      }
+      const card = document.createElement('div');
+      card.className = 'asset-card';
+      if (entry.selected) {
+        card.classList.add('selected');
+      }
+      if (entry.locked) {
+        card.classList.add('locked');
+      }
+      const dataset = card.dataset;
+      dataset.id = entry.id;
+      dataset.type = entry.type || 'extra';
+      dataset.locked = entry.locked ? 'true' : 'false';
+
+      const source = entry.source || {};
+      if (source.url) {
+        dataset.url = source.url;
+      }
+      if (source.zip) {
+        dataset.zip = source.zip;
+      }
+      if (source.entry) {
+        dataset.entry = source.entry;
+      }
+
+      const thumbnail = entry.thumbnail || {};
+      if (thumbnail.url) {
+        dataset.thumb = thumbnail.url;
+      }
+      if (thumbnail.zip) {
+        dataset.thumbZip = thumbnail.zip;
+      }
+      if (thumbnail.entry) {
+        dataset.thumbEntry = thumbnail.entry;
+      }
+      if (!thumbnail.url && !thumbnail.zip) {
+        dataset.thumb = 'public/images/wawasensei-white.png';
+      }
+
+      if (entry.pose) {
+        dataset.pose = entry.pose;
+      }
+
+      const labels = entry.labels || {};
+      const icons = entry.icons || {};
+      dataset.labelActive = labels.active || 'Equipped';
+      dataset.labelInactive = labels.inactive || 'Tap to equip';
+      dataset.iconActive = icons.active || 'bi-check2-circle';
+      dataset.iconInactive = icons.inactive || 'bi-plus-circle';
+
+      card.setAttribute('role', 'listitem');
+      card.setAttribute('tabindex', '0');
+      card.setAttribute('aria-pressed', entry.selected ? 'true' : 'false');
+
+      const badge = entry.badge || 'Asset';
+      const eyebrow = entry.eyebrow || 'Wardrobe';
+      const title = entry.title || entry.id;
+      const description = entry.description || '';
+      const metaLabel = entry.selected ? dataset.labelActive : dataset.labelInactive;
+      const metaIcon = entry.selected ? dataset.iconActive : dataset.iconInactive;
+
+      card.innerHTML = `
+        <div class="card-visual" aria-hidden="true">
+          <span class="card-badge">${badge}</span>
+          <img src="public/images/wawasensei-white.png" alt="${title} thumbnail" aria-hidden="true">
+          <span class="card-watermark" aria-hidden="true">SENSEI</span>
+        </div>
+        <div class="card-body">
+          <span class="card-eyebrow">${eyebrow}</span>
+          <h2 class="card-title">${title}</h2>
+          <p class="card-text">${description}</p>
+        </div>
+        <div class="card-meta" data-label-active="${dataset.labelActive}" data-label-inactive="${dataset.labelInactive}" data-icon-active="${dataset.iconActive}" data-icon-inactive="${dataset.iconInactive}">
+          <i class="bi ${metaIcon}" aria-hidden="true"></i>
+          <span>${metaLabel}</span>
+        </div>
+      `;
+
+      return card;
+    }
+
+    function populateAssetGrid(manifest) {
+      const grid = document.getElementById('assetGrid');
+      if (!grid) {
+        return;
+      }
+      assetRegistry.clear();
+      grid.innerHTML = '';
+      manifest.forEach((entry) => {
+        if (!entry || !entry.id) {
+          return;
+        }
+        assetRegistry.set(entry.id, entry);
+        const card = createAssetCard(entry);
+        if (card) {
+          grid.appendChild(card);
+        }
+      });
+    }
+
+    async function loadAssetManifest() {
+      if (!assetManifestUrl) {
+        return [];
+      }
+      if (!assetManifestPromise) {
+        assetManifestPromise = fetch(assetManifestUrl, { cache: 'no-cache' })
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`Failed to load asset manifest: ${response.status} ${response.statusText}`);
+            }
+            return response.json();
+          })
+          .catch((error) => {
+            console.error('Unable to fetch asset manifest', error);
+            return [];
+          });
+      }
+      return assetManifestPromise;
+    }
+
+    async function bootstrapAssetGrid() {
+      const manifest = await loadAssetManifest();
+      if (!Array.isArray(manifest) || manifest.length === 0) {
+        console.warn('Asset manifest is empty; no selector cards were generated.');
+        return;
+      }
+      populateAssetGrid(manifest);
+      initializeCardInteractions();
+    }
+
 
     async function getZipFile(zipPath) {
       if (zipFileCache.has(zipPath)) {
@@ -1267,104 +1104,120 @@
     }
 
     const colorInput = document.getElementById('colorInput');
-    let currentColor = colorInput.value;
+    let currentColor = colorInput ? colorInput.value : '#9c7bff';
 
-    document.querySelectorAll('#assetGrid .asset-card').forEach((card) => {
-      const cardId = card.dataset.id || card.dataset.entry || card.dataset.url;
-      const registry = cardId ? assetRegistry.get(cardId) : null;
-      const fallbackSource = {
-        url: card.dataset.url || undefined,
-        zip: card.dataset.zip || undefined,
-        entry: card.dataset.entry || undefined,
-      };
-      const resolvedSource = registry?.source || fallbackSource;
-      const assetSource = resolvedSource && (resolvedSource.url || (resolvedSource.zip && resolvedSource.entry))
-        ? resolvedSource
-        : null;
-      const type = registry?.type || card.dataset.type || 'extra';
-      const locked = registry?.locked ?? (card.dataset.locked === 'true');
-      const poseName = registry?.pose || card.dataset.pose || cardId;
-      let isSelected = card.classList.contains('selected');
+    function initializeCardInteractions() {
+      const cards = document.querySelectorAll('#assetGrid .asset-card');
+      cards.forEach((card) => {
+        const cardId = card.dataset.id || card.dataset.entry || card.dataset.url;
+        const registry = cardId ? assetRegistry.get(cardId) : null;
+        const fallbackSource = {
+          url: card.dataset.url || undefined,
+          zip: card.dataset.zip || undefined,
+          entry: card.dataset.entry || undefined,
+        };
+        const resolvedSource = registry?.source || fallbackSource;
+        const assetSource = resolvedSource && (resolvedSource.url || (resolvedSource.zip && resolvedSource.entry))
+          ? resolvedSource
+          : null;
+        const type = registry?.type || card.dataset.type || 'extra';
+        const locked = registry?.locked ?? (card.dataset.locked === 'true');
+        const poseName = registry?.pose || card.dataset.pose || cardId;
+        let isSelected = card.classList.contains('selected');
 
-      loadCardThumbnail(card);
-      setCardState(card, isSelected);
+        loadCardThumbnail(card);
 
-      const handleToggle = async () => {
+        if (type === 'attachment') {
+          setCardState(card, true);
+          card.setAttribute('aria-pressed', 'true');
+          return;
+        }
+
+        setCardState(card, isSelected);
+
+        const handleToggle = async () => {
+          if (type === 'avatar') {
+            if (!assetSource) {
+              console.warn(`No asset source registered for avatar card "${cardId}"`);
+              return;
+            }
+            isSelected = true;
+            setCardState(card, true);
+            await loadAvatar(assetSource);
+            return;
+          }
+
+          if (type === 'pose') {
+            if (locked) {
+              return;
+            }
+            if (activePoseCard === card) {
+              setCardState(card, false);
+              activePoseCard = null;
+              clearActivePose();
+              frame(modelGroup);
+            } else {
+              if (activePoseCard) {
+                setCardState(activePoseCard, false);
+              }
+              activePoseCard = card;
+              activePoseName = poseName;
+              setCardState(card, true);
+              await applyPoseByName(poseName);
+              frame(modelGroup);
+            }
+            return;
+          }
+
+          if (locked) {
+            return;
+          }
+
+          isSelected = !isSelected;
+          setCardState(card, isSelected);
+          if (isSelected) {
+            if (!assetSource) {
+              console.warn(`No asset source registered for card "${cardId}"`);
+              setCardState(card, false);
+              isSelected = false;
+              return;
+            }
+            loadExtra(assetSource, cardId, card);
+          } else {
+            removeExtra(cardId);
+          }
+        };
+
+        if (!locked) {
+          card.addEventListener('click', handleToggle);
+          card.addEventListener('keydown', (event) => {
+            if (event.key === ' ' || event.key === 'Enter') {
+              event.preventDefault();
+              handleToggle();
+            }
+          });
+        }
+
         if (type === 'avatar') {
           if (!assetSource) {
             console.warn(`No asset source registered for avatar card "${cardId}"`);
             return;
           }
-          isSelected = true;
           setCardState(card, true);
-          await loadAvatar(assetSource);
-          return;
-        }
-
-        if (type === 'pose') {
-          if (locked) {
-            return;
-          }
-          if (activePoseCard === card) {
-            setCardState(card, false);
-            activePoseCard = null;
-            clearActivePose();
-            frame(modelGroup);
-          } else {
-            if (activePoseCard) {
-              setCardState(activePoseCard, false);
-            }
+          loadAvatar(assetSource);
+        } else if (type === 'pose') {
+          if (card.classList.contains('selected')) {
             activePoseCard = card;
             activePoseName = poseName;
-            setCardState(card, true);
-            await applyPoseByName(poseName);
-            frame(modelGroup);
+            applyPoseByName(activePoseName).then(() => {
+              frame(modelGroup);
+            });
           }
-          return;
-        }
-
-        if (locked) {
-          return;
-        }
-
-        isSelected = !isSelected;
-        setCardState(card, isSelected);
-        if (isSelected) {
-          if (!assetSource) {
-            console.warn(`No asset source registered for card "${cardId}"`);
-            setCardState(card, false);
-            isSelected = false;
-            return;
-          }
+        } else if (isSelected && assetSource) {
           loadExtra(assetSource, cardId, card);
-        } else {
-          removeExtra(cardId);
-        }
-      };
-
-      card.addEventListener('click', handleToggle);
-      card.addEventListener('keydown', (event) => {
-        if (event.key === ' ' || event.key === 'Enter') {
-          event.preventDefault();
-          handleToggle();
         }
       });
-
-      if (type === 'avatar') {
-        setCardState(card, true);
-        loadAvatar(assetSource);
-      } else if (type === 'pose') {
-        if (card.classList.contains('selected')) {
-          activePoseCard = card;
-          activePoseName = card.dataset.pose || cardId;
-          applyPoseByName(activePoseName).then(() => {
-            frame(modelGroup);
-          });
-        }
-      } else if (isSelected) {
-        loadExtra(assetSource, cardId, card);
-      }
-    });
+    }
 
     function animate() {
       requestAnimationFrame(animate);
@@ -1372,12 +1225,16 @@
     }
     animate();
 
-    colorInput.addEventListener('input', (event) => {
-      currentColor = event.target.value;
-      tintTargets.forEach((target) => {
-        applyColor(target, currentColor);
+    if (colorInput) {
+      colorInput.addEventListener('input', (event) => {
+        currentColor = event.target.value;
+        tintTargets.forEach((target) => {
+          applyColor(target, currentColor);
+        });
       });
-    });
+    }
+
+    bootstrapAssetGrid();
 
     window.addEventListener('resize', resizeRenderer);
   </script>

--- a/index.html
+++ b/index.html
@@ -3,60 +3,438 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Bootstrap Avatar Preview</title>
+  <title>Avatar Outfit Editor</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
   <style>
-    body { margin: 0; }
-    canvas { width: 100%; height: 100%; display: block; }
-    .sidebar { width: 4rem; }
-    .asset-card { cursor: pointer; }
-    .asset-card.selected { outline: 2px solid #0d6efd; }
+    :root {
+      --sidebar-bg: rgba(15, 11, 53, 0.55);
+      --sidebar-border: rgba(255, 255, 255, 0.12);
+      --panel-bg: rgba(255, 255, 255, 0.96);
+      --panel-text: #171836;
+      --accent: #6257ff;
+      --accent-dark: #3529ff;
+      --accent-soft: #ebe8ff;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Manrope', sans-serif;
+      background: radial-gradient(circle at top left, #5a1bff 0%, #1f0061 38%, #080020 100%);
+      color: #f3f4ff;
+    }
+
+    canvas {
+      width: 100% !important;
+      height: 100% !important;
+      display: block;
+    }
+
+    .app-shell {
+      display: flex;
+      min-height: 100vh;
+      overflow: hidden;
+    }
+
+    .sidebar {
+      width: 88px;
+      background: var(--sidebar-bg);
+      backdrop-filter: blur(18px);
+      border-right: 1px solid var(--sidebar-border);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 2rem 1rem;
+      gap: 1rem;
+    }
+
+    .sidebar .logo {
+      width: 48px;
+      height: 48px;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.08);
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      font-size: 1.125rem;
+    }
+
+    .sidebar .nav-link {
+      width: 52px;
+      height: 52px;
+      border-radius: 18px;
+      display: grid;
+      place-items: center;
+      color: rgba(255, 255, 255, 0.6);
+      background: transparent;
+      border: 1px solid transparent;
+      transition: 0.25s ease;
+      font-size: 1.3rem;
+    }
+
+    .sidebar .nav-link:hover {
+      color: #ffffff;
+      border-color: rgba(255, 255, 255, 0.25);
+      background: rgba(255, 255, 255, 0.05);
+    }
+
+    .sidebar .nav-link.active {
+      background: linear-gradient(135deg, #725fff 0%, #4c2fff 100%);
+      color: #ffffff;
+      box-shadow: 0 12px 32px rgba(68, 52, 255, 0.45);
+    }
+
+    .content-layout {
+      flex: 1;
+      display: flex;
+      gap: 2.5rem;
+      padding: 2.5rem 3rem;
+    }
+
+    .customizer-panel {
+      width: 100%;
+      max-width: 520px;
+      background: var(--panel-bg);
+      color: var(--panel-text);
+      border-radius: 32px;
+      padding: 2.5rem;
+      box-shadow: 0 25px 60px rgba(10, 10, 60, 0.25);
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .panel-eyebrow {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      font-weight: 700;
+      color: #8a8bb5;
+    }
+
+    .panel-title {
+      font-weight: 700;
+      color: var(--panel-text);
+    }
+
+    .section-tabs {
+      display: flex;
+      gap: 0.75rem;
+    }
+
+    .btn-tab {
+      border-radius: 999px !important;
+      border: 1px solid transparent;
+      background: #ececff;
+      color: var(--accent);
+      font-weight: 600;
+      padding: 0.55rem 1.6rem;
+      box-shadow: none;
+      transition: 0.2s ease;
+    }
+
+    .btn-tab:hover {
+      border-color: rgba(98, 87, 255, 0.35);
+    }
+
+    .btn-tab.active {
+      background: linear-gradient(135deg, #7365ff 0%, #4331ff 100%);
+      color: #ffffff;
+      box-shadow: 0 12px 32px rgba(68, 52, 255, 0.35);
+    }
+
+    .panel-actions {
+      display: flex;
+      gap: 0.75rem;
+    }
+
+    .panel-actions .btn {
+      border-radius: 999px;
+      padding-inline: 1.6rem;
+      font-weight: 600;
+    }
+
+    .panel-actions .btn-outline-secondary {
+      border-color: rgba(16, 14, 65, 0.12);
+      color: var(--panel-text);
+    }
+
+    .panel-actions .btn-outline-secondary:hover {
+      background: rgba(16, 14, 65, 0.08);
+      color: var(--panel-text);
+    }
+
+    .panel-actions .btn-primary {
+      background: linear-gradient(135deg, #7d6fff 0%, #4c37ff 100%);
+      border: none;
+      box-shadow: 0 18px 40px rgba(76, 55, 255, 0.35);
+    }
+
+    .panel-actions .btn-primary:hover {
+      filter: brightness(1.05);
+    }
+
+    .asset-grid {
+      flex: 1;
+      overflow-y: auto;
+      padding-right: 0.35rem;
+    }
+
+    .asset-grid::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    .asset-grid::-webkit-scrollbar-thumb {
+      background: rgba(12, 12, 60, 0.14);
+      border-radius: 3px;
+    }
+
+    .asset-card {
+      border: none;
+      border-radius: 24px;
+      background: #f4f5ff;
+      transition: 0.2s ease;
+      height: 100%;
+      box-shadow: 0 12px 30px rgba(19, 15, 78, 0.08);
+      cursor: pointer;
+    }
+
+    .asset-card img {
+      border-radius: 20px 20px 12px 12px;
+      object-fit: cover;
+    }
+
+    .asset-card .card-body {
+      padding: 1rem 1.2rem 1.2rem;
+    }
+
+    .asset-card .card-title {
+      font-size: 1rem;
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    .asset-card .card-text {
+      font-size: 0.8rem;
+      color: #7a7ba5;
+    }
+
+    .asset-card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 20px 45px rgba(25, 21, 95, 0.16);
+    }
+
+    .asset-card.selected {
+      background: var(--accent-soft);
+      box-shadow: 0 0 0 3px rgba(98, 87, 255, 0.9), 0 24px 48px rgba(66, 55, 255, 0.35);
+    }
+
+    .viewer-pane {
+      flex: 1;
+      display: flex;
+      align-items: stretch;
+    }
+
+    .viewer-wrapper {
+      position: relative;
+      flex: 1;
+      border-radius: 42px;
+      background: linear-gradient(155deg, #6732ff 0%, #2b0a73 50%, #0a0229 100%);
+      box-shadow: 0 30px 80px rgba(18, 10, 60, 0.65);
+      overflow: hidden;
+      min-height: 520px;
+    }
+
+    #viewer {
+      position: absolute;
+      inset: 0;
+    }
+
+    .viewer-overlay {
+      position: absolute;
+      top: 28px;
+      right: 28px;
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 20px;
+      padding: 1rem 1.25rem;
+      backdrop-filter: blur(18px);
+      color: #ffffff;
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      min-width: 160px;
+    }
+
+    .viewer-overlay label {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      opacity: 0.8;
+      font-weight: 600;
+    }
+
+    .viewer-overlay input[type="color"] {
+      width: 64px;
+      height: 36px;
+      border: none;
+      border-radius: 12px;
+      background: transparent;
+      padding: 0;
+      cursor: pointer;
+    }
+
+    @media (max-width: 1199.98px) {
+      .content-layout {
+        padding: 2rem;
+        gap: 2rem;
+      }
+    }
+
+    @media (max-width: 991.98px) {
+      .app-shell {
+        flex-direction: column;
+      }
+
+      .sidebar {
+        width: 100%;
+        flex-direction: row;
+        justify-content: center;
+        border-right: none;
+        border-bottom: 1px solid var(--sidebar-border);
+        padding: 1rem;
+      }
+
+      .content-layout {
+        flex-direction: column;
+      }
+
+      .customizer-panel {
+        max-width: none;
+      }
+
+      .viewer-wrapper {
+        min-height: 420px;
+      }
+    }
+
+    @media (max-width: 575.98px) {
+      .content-layout {
+        padding: 1.5rem 1.25rem 2.5rem;
+      }
+
+      .customizer-panel {
+        padding: 1.75rem;
+      }
+
+      .panel-actions {
+        display: none;
+      }
+    }
   </style>
 </head>
 <body>
-  <div class="container-fluid">
-    <div class="row">
-      <nav class="sidebar col-auto bg-dark min-vh-100 d-flex flex-column align-items-center py-3 text-white">
-        <button class="btn btn-dark mb-3 active"><i class="bi bi-person"></i></button>
-        <button class="btn btn-dark"><i class="bi bi-tshirt"></i></button>
-      </nav>
-      <main class="col-md-7 py-3">
-        <h1 class="h4 mb-3">Assets</h1>
-        <div id="assetGrid" class="row row-cols-2 row-cols-md-3 g-3">
-          <div class="col">
-            <div class="card asset-card selected" data-url="public/models/Teleporter Base.glb">
-              <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Teleporter Base">
-              <div class="card-body p-2 text-center">
-                <p class="card-text small mb-0">Teleporter Base</p>
+  <div class="app-shell">
+    <nav class="sidebar">
+      <div class="logo">N</div>
+      <a class="nav-link active" href="#" aria-label="Appearance"><i class="bi bi-person"></i></a>
+      <a class="nav-link" href="#" aria-label="Wardrobe"><i class="bi bi-tshirt"></i></a>
+      <a class="nav-link" href="#" aria-label="Accessories"><i class="bi bi-sunglasses"></i></a>
+      <a class="nav-link" href="#" aria-label="Settings"><i class="bi bi-sliders"></i></a>
+    </nav>
+
+    <div class="content-layout">
+      <section class="customizer-panel">
+        <div class="d-flex align-items-start justify-content-between gap-3">
+          <div>
+            <p class="panel-eyebrow mb-1">Outfit</p>
+            <h1 class="panel-title h3 mb-0">Asset Library</h1>
+            <p class="text-muted small mb-0">Toggle modular pieces to build the perfect hero look.</p>
+          </div>
+          <div class="panel-actions d-none d-md-flex">
+            <button type="button" class="btn btn-outline-secondary">Discard</button>
+            <button type="button" class="btn btn-primary">Save &amp; Load</button>
+          </div>
+        </div>
+
+        <div class="section-tabs">
+          <button type="button" class="btn btn-tab active">Appearance</button>
+          <button type="button" class="btn btn-tab">Outfit</button>
+          <button type="button" class="btn btn-tab">Extras</button>
+        </div>
+
+        <div class="asset-grid" role="list">
+          <div id="assetGrid" class="row row-cols-2 row-cols-md-3 g-3">
+            <div class="col">
+              <div class="card asset-card selected" data-url="public/models/Teleporter Base.glb">
+                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Teleporter Base">
+                <div class="card-body">
+                  <h2 class="card-title">Teleporter Base</h2>
+                  <p class="card-text">Foundation platform</p>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="col">
-            <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-              <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Hair">
-              <div class="card-body p-2 text-center">
-                <p class="card-text small mb-0">Hair</p>
+            <div class="col">
+              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Arm Cuffs">
+                <div class="card-body">
+                  <h2 class="card-title">Arm Cuffs</h2>
+                  <p class="card-text">Layered accessory</p>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="col">
-            <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-              <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Top">
-              <div class="card-body p-2 text-center">
-                <p class="card-text small mb-0">Top</p>
+            <div class="col">
+              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Outer Jacket">
+                <div class="card-body">
+                  <h2 class="card-title">Outer Jacket</h2>
+                  <p class="card-text">Add bold color blocking</p>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Sneakers">
+                <div class="card-body">
+                  <h2 class="card-title">Sneakers</h2>
+                  <p class="card-text">High-top option</p>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Visor">
+                <div class="card-body">
+                  <h2 class="card-title">Visor</h2>
+                  <p class="card-text">Futuristic eyewear</p>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Backpack">
+                <div class="card-body">
+                  <h2 class="card-title">Backpack</h2>
+                  <p class="card-text">Utility ready</p>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </main>
-      <aside class="col-md-5 py-3 d-flex flex-column">
-        <div id="viewer" class="border rounded mb-3 flex-grow-1" style="min-height:400px"></div>
-        <div class="mb-3">
-          <label for="colorInput" class="form-label">Body Color</label>
-          <input type="color" class="form-control form-control-color" id="colorInput" value="#ffccaa">
+      </section>
+
+      <section class="viewer-pane">
+        <div class="viewer-wrapper" id="viewerWrapper">
+          <div id="viewer"></div>
+          <div class="viewer-overlay">
+            <label for="colorInput">Primary Color</label>
+            <input type="color" id="colorInput" value="#9c7bff" aria-label="Choose avatar color">
+          </div>
         </div>
-      </aside>
+      </section>
     </div>
   </div>
 
@@ -77,15 +455,33 @@
 
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
-    const renderer = new THREE.WebGLRenderer({ antialias: true });
-    const viewer = document.getElementById('viewer');
-    renderer.setSize(viewer.clientWidth, viewer.clientHeight);
-    viewer.appendChild(renderer.domElement);
-    camera.aspect = viewer.clientWidth / viewer.clientHeight;
-    camera.updateProjectionMatrix();
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
 
-    const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.0);
-    scene.add(light);
+    const viewerWrapper = document.getElementById('viewerWrapper');
+    const viewer = document.getElementById('viewer');
+    viewer.appendChild(renderer.domElement);
+
+    function resizeRenderer() {
+      const width = viewerWrapper.clientWidth;
+      const height = viewerWrapper.clientHeight;
+      renderer.setSize(width, height, false);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    }
+
+    resizeRenderer();
+
+    const hemisphere = new THREE.HemisphereLight(0xffffff, 0x2b1a63, 1.05);
+    scene.add(hemisphere);
+
+    const keyLight = new THREE.DirectionalLight(0xffffff, 0.6);
+    keyLight.position.set(4, 6, 6);
+    scene.add(keyLight);
+
+    const rimLight = new THREE.DirectionalLight(0x7c5bff, 0.9);
+    rimLight.position.set(-4, 5, -6);
+    scene.add(rimLight);
 
     const modelGroup = new THREE.Group();
     scene.add(modelGroup);
@@ -105,9 +501,9 @@
       const maxDim = Math.max(size.x, size.y, size.z);
       const fov = camera.fov * (Math.PI / 180);
       let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
-      cameraZ *= 1.5;
-      camera.position.set(0, size.y * 0.5, cameraZ);
-      camera.lookAt(0, 0, 0);
+      cameraZ *= 1.6;
+      camera.position.set(0, size.y * 0.45, cameraZ);
+      camera.lookAt(0, 0.6, 0);
     }
 
     loader.load('public/models/Armature.glb', (gltf) => {
@@ -149,26 +545,21 @@
 
     function animate() {
       requestAnimationFrame(animate);
-      modelGroup.rotation.y += 0.005;
+      modelGroup.rotation.y += 0.0045;
       renderer.render(scene, camera);
     }
     animate();
 
-    document.getElementById('colorInput').addEventListener('input', (e) => {
+    document.getElementById('colorInput').addEventListener('input', (event) => {
       if (!avatar) return;
       avatar.traverse((child) => {
         if (child.isMesh && child.material && child.material.color) {
-          child.material.color.set(e.target.value);
+          child.material.color.set(event.target.value);
         }
       });
     });
 
-    window.addEventListener('resize', () => {
-      const { clientWidth, clientHeight } = viewer;
-      renderer.setSize(clientWidth, clientHeight);
-      camera.aspect = clientWidth / clientHeight;
-      camera.updateProjectionMatrix();
-    });
+    window.addEventListener('resize', resizeRenderer);
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
             class="asset-card"
             data-id="wardrobe-crown"
             data-zip="Assets.zip"
-            data-entry="Assets/Hat.006.glb"
+            data-entry="Assets/Hat.001.glb"
             data-thumb-zip="Assets.zip"
             data-thumb-entry="Assets/thumbnail_crown.png"
             data-label-active="Equipped"
@@ -662,7 +662,7 @@
             <div class="card-body">
               <span class="card-eyebrow">Accessories · Head</span>
               <h2 class="card-title">Crown Halo</h2>
-              <p class="card-text">Adds the halo crown from Assets/Hat.006.glb for a regal accent.</p>
+              <p class="card-text">Adds the golden crown from Assets/Hat.001.glb for a regal accent.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-plus-circle" aria-hidden="true"></i>
@@ -837,6 +837,65 @@
     const extras = new Map();
     const tintTargets = new Set();
     const skinnedRoots = new Set();
+    const assetRegistry = new Map([
+      [
+        'core-hero',
+        {
+          type: 'avatar',
+          locked: true,
+          source: { zip: 'Assets.zip', entry: 'Assets/NakedFullBody.glb' },
+        },
+      ],
+      [
+        'platform-teleporter',
+        {
+          type: 'extra',
+          source: { url: 'public/models/Teleporter Base.glb' },
+        },
+      ],
+      [
+        'wardrobe-hair',
+        {
+          type: 'extra',
+          source: { zip: 'Assets.zip', entry: 'Assets/Hair.010.glb' },
+        },
+      ],
+      [
+        'wardrobe-dress',
+        {
+          type: 'extra',
+          source: { zip: 'Assets.zip', entry: 'Assets/WawaDress.glb' },
+        },
+      ],
+      [
+        'wardrobe-crown',
+        {
+          type: 'extra',
+          source: { zip: 'Assets.zip', entry: 'Assets/Hat.001.glb' },
+        },
+      ],
+      [
+        'wardrobe-bunny',
+        {
+          type: 'extra',
+          source: { zip: 'Assets.zip', entry: 'Assets/Hat.007.glb' },
+        },
+      ],
+      [
+        'wardrobe-shoes',
+        {
+          type: 'extra',
+          source: { zip: 'Assets.zip', entry: 'Assets/Shoes.002.glb' },
+        },
+      ],
+      [
+        'pose-idle',
+        {
+          type: 'pose',
+          pose: 'Idle',
+        },
+      ],
+    ]);
     let activePoseName = null;
     let activePoseCard = null;
     let poseClipMapPromise = null;
@@ -1110,6 +1169,10 @@
     }
 
     async function loadAvatar(source) {
+      if (!source || (!source.url && !(source.zip && source.entry))) {
+        console.warn('Avatar source missing or incomplete, skipping load.');
+        return;
+      }
       const loadToken = ++avatarLoadToken;
       try {
         const gltf = await loadGLTFAsset(source);
@@ -1163,6 +1226,10 @@
     }
 
     async function loadExtra(source, key, card) {
+      if (!source || (!source.url && !(source.zip && source.entry))) {
+        console.warn(`Skipping extra "${key}" because its source is undefined.`);
+        return;
+      }
       if (extras.has(key)) {
         return;
       }
@@ -1203,14 +1270,20 @@
     let currentColor = colorInput.value;
 
     document.querySelectorAll('#assetGrid .asset-card').forEach((card) => {
-      const assetSource = {
+      const cardId = card.dataset.id || card.dataset.entry || card.dataset.url;
+      const registry = cardId ? assetRegistry.get(cardId) : null;
+      const fallbackSource = {
         url: card.dataset.url || undefined,
         zip: card.dataset.zip || undefined,
         entry: card.dataset.entry || undefined,
       };
-      const cardId = card.dataset.id || card.dataset.entry || card.dataset.url;
-      const type = card.dataset.type || 'extra';
-      const locked = card.dataset.locked === 'true';
+      const resolvedSource = registry?.source || fallbackSource;
+      const assetSource = resolvedSource && (resolvedSource.url || (resolvedSource.zip && resolvedSource.entry))
+        ? resolvedSource
+        : null;
+      const type = registry?.type || card.dataset.type || 'extra';
+      const locked = registry?.locked ?? (card.dataset.locked === 'true');
+      const poseName = registry?.pose || card.dataset.pose || cardId;
       let isSelected = card.classList.contains('selected');
 
       loadCardThumbnail(card);
@@ -1218,6 +1291,10 @@
 
       const handleToggle = async () => {
         if (type === 'avatar') {
+          if (!assetSource) {
+            console.warn(`No asset source registered for avatar card "${cardId}"`);
+            return;
+          }
           isSelected = true;
           setCardState(card, true);
           await loadAvatar(assetSource);
@@ -1228,7 +1305,6 @@
           if (locked) {
             return;
           }
-          const poseName = card.dataset.pose || cardId;
           if (activePoseCard === card) {
             setCardState(card, false);
             activePoseCard = null;
@@ -1254,6 +1330,12 @@
         isSelected = !isSelected;
         setCardState(card, isSelected);
         if (isSelected) {
+          if (!assetSource) {
+            console.warn(`No asset source registered for card "${cardId}"`);
+            setCardState(card, false);
+            isSelected = false;
+            return;
+          }
           loadExtra(assetSource, cardId, card);
         } else {
           removeExtra(cardId);

--- a/index.html
+++ b/index.html
@@ -591,6 +591,60 @@
     const modelGroup = new THREE.Group();
     scene.add(modelGroup);
 
+    function slugify(value) {
+      if (!value && value !== 0) {
+        return null;
+      }
+      return String(value)
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || null;
+    }
+
+    function deriveSlotFromSource(source) {
+      if (!source) {
+        return null;
+      }
+      const path = source.entry || source.url;
+      if (!path) {
+        return null;
+      }
+      const filename = path.split('/').pop() || '';
+      if (!filename) {
+        return null;
+      }
+      const withoutExt = filename.replace(/\.[^/.]+$/, '');
+      const base = withoutExt.replace(/[._-]?\d+$/i, '');
+      return slugify(base);
+    }
+
+    function resolveSlotId(entry) {
+      if (!entry) {
+        return null;
+      }
+      if (entry.slot) {
+        return slugify(entry.slot);
+      }
+      if (entry.group) {
+        return slugify(entry.group);
+      }
+      if (entry.category) {
+        return slugify(entry.category);
+      }
+      const fromSource = deriveSlotFromSource(entry.source || {});
+      if (fromSource) {
+        return fromSource;
+      }
+      if (entry.eyebrow) {
+        return slugify(entry.eyebrow);
+      }
+      if (entry.badge && entry.title) {
+        return slugify(`${entry.badge}-${entry.title}`);
+      }
+      return null;
+    }
+
     const heroBodyPieces = [
       { key: 'head', source: { zip: 'Assets.zip', entry: 'Assets/Head.001.glb' }, tint: true },
       { key: 'face', source: { zip: 'Assets.zip', entry: 'Assets/Face.001.glb' }, tint: true },
@@ -599,9 +653,14 @@
       { key: 'nose', source: { zip: 'Assets.zip', entry: 'Assets/Nose.001.glb' }, tint: true },
     ];
 
+    heroBodyPieces.forEach((piece) => {
+      piece.slot = piece.slot || deriveSlotFromSource(piece.source) || slugify(piece.key);
+    });
+
     let avatar;
     const avatarAttachments = new Map();
     const extras = new Map();
+    const slotSelections = new Map();
     const tintTargets = new Set();
     const skinnedRoots = new Set();
     const assetRegistry = new Map();
@@ -635,6 +694,11 @@
       dataset.id = entry.id;
       dataset.type = entry.type || 'extra';
       dataset.locked = entry.locked ? 'true' : 'false';
+      const slotId = resolveSlotId(entry);
+      if (slotId) {
+        dataset.slot = slotId;
+      }
+      dataset.exclusive = entry.exclusive === false ? 'false' : 'true';
 
       const source = entry.source || {};
       if (source.url) {
@@ -979,11 +1043,102 @@
     }
 
     function clearAvatarAttachments() {
-      avatarAttachments.forEach((object) => {
-        modelGroup.remove(object);
-        unregisterSkinnedRoot(object);
+      avatarAttachments.forEach((attachment) => {
+        if (attachment && attachment.object) {
+          modelGroup.remove(attachment.object);
+          unregisterSkinnedRoot(attachment.object);
+        }
       });
       avatarAttachments.clear();
+    }
+
+    function hideAvatarAttachmentBySlot(slotId) {
+      if (!slotId) {
+        return false;
+      }
+      let changed = false;
+      avatarAttachments.forEach((attachment) => {
+        if (!attachment || attachment.slot !== slotId || attachment.visible === false) {
+          return;
+        }
+        if (attachment.object) {
+          modelGroup.remove(attachment.object);
+          unregisterSkinnedRoot(attachment.object);
+        }
+        attachment.visible = false;
+        changed = true;
+      });
+      return changed;
+    }
+
+    function showAvatarAttachmentBySlot(slotId) {
+      if (!slotId) {
+        return false;
+      }
+      let changed = false;
+      avatarAttachments.forEach((attachment) => {
+        if (!attachment || attachment.slot !== slotId || attachment.visible !== false) {
+          return;
+        }
+        if (attachment.object) {
+          modelGroup.add(attachment.object);
+          registerSkinnedRoot(attachment.object);
+        }
+        attachment.visible = true;
+        changed = true;
+      });
+      return changed;
+    }
+
+    function registerSlotSelection(slotId, details) {
+      if (!slotId || !details) {
+        return;
+      }
+      slotSelections.set(slotId, details);
+      hideAvatarAttachmentBySlot(slotId);
+    }
+
+    function clearSlotSelection(slotId, cardId) {
+      if (!slotId) {
+        return;
+      }
+      const active = slotSelections.get(slotId);
+      if (!active) {
+        return;
+      }
+      if (!cardId || active.cardId === cardId) {
+        slotSelections.delete(slotId);
+      }
+    }
+
+    function enforceSlotExclusivity(slotId, nextCardId) {
+      if (!slotId) {
+        return;
+      }
+      const active = slotSelections.get(slotId);
+      if (!active || active.cardId === nextCardId) {
+        return;
+      }
+      setCardState(active.card, false);
+      removeExtra(active.cardId);
+      slotSelections.delete(slotId);
+    }
+
+    function maybeRestoreDefaultSlot(slotId) {
+      if (!slotId) {
+        return;
+      }
+      if (slotSelections.has(slotId)) {
+        return;
+      }
+      if (showAvatarAttachmentBySlot(slotId)) {
+        if (activePoseName) {
+          reapplyActivePose();
+        } else {
+          resetAllSkinnedMeshesPose();
+        }
+        frame(modelGroup);
+      }
     }
 
     function setCardState(card, isSelected) {
@@ -1042,12 +1197,21 @@
               return;
             }
             const object = attachmentGltf.scene;
-            avatarAttachments.set(piece.key, object);
+            const attachmentData = {
+              object,
+              slot: piece.slot || deriveSlotFromSource(piece.source) || slugify(piece.key),
+              tint: !!piece.tint,
+              visible: true,
+            };
+            avatarAttachments.set(piece.key, attachmentData);
             modelGroup.add(object);
             registerSkinnedRoot(object);
-            if (piece.tint) {
+            if (attachmentData.tint) {
               tintTargets.add(object);
               applyColor(object, currentColor);
+            }
+            if (attachmentData.slot && slotSelections.has(attachmentData.slot)) {
+              hideAvatarAttachmentBySlot(attachmentData.slot);
             }
           } catch (pieceError) {
             console.error(`Failed to load core body piece "${piece.key}"`, pieceError);
@@ -1072,15 +1236,15 @@
     async function loadExtra(source, key, card) {
       if (!source || (!source.url && !(source.zip && source.entry))) {
         console.warn(`Skipping extra "${key}" because its source is undefined.`);
-        return;
+        return false;
       }
       if (extras.has(key)) {
-        return;
+        return true;
       }
       try {
         const gltf = await loadGLTFAsset(source);
         if (!card.classList.contains('selected')) {
-          return;
+          return false;
         }
         const obj = gltf.scene;
         extras.set(key, obj);
@@ -1090,8 +1254,10 @@
           await applyPoseByName(activePoseName);
         }
         frame(modelGroup);
+        return true;
       } catch (error) {
         console.error(`Failed to load asset "${key}"`, error);
+        return false;
       }
     }
 
@@ -1130,7 +1296,11 @@
         const type = registry?.type || card.dataset.type || 'extra';
         const locked = registry?.locked ?? (card.dataset.locked === 'true');
         const poseName = registry?.pose || card.dataset.pose || cardId;
-        let isSelected = card.classList.contains('selected');
+        let slotId = card.dataset.slot || resolveSlotId(registry) || deriveSlotFromSource(resolvedSource) || null;
+        if (slotId) {
+          card.dataset.slot = slotId;
+        }
+        const exclusive = registry?.exclusive === false || card.dataset.exclusive === 'false' ? false : true;
 
         loadCardThumbnail(card);
 
@@ -1140,21 +1310,21 @@
           return;
         }
 
-        setCardState(card, isSelected);
+        const initiallySelected = card.classList.contains('selected');
+        setCardState(card, initiallySelected);
 
-        const handleToggle = async () => {
-          if (type === 'avatar') {
-            if (!assetSource) {
-              console.warn(`No asset source registered for avatar card "${cardId}"`);
-              return;
-            }
-            isSelected = true;
-            setCardState(card, true);
-            await loadAvatar(assetSource);
+        if (type === 'avatar') {
+          if (!assetSource) {
+            console.warn(`No asset source registered for avatar card "${cardId}"`);
             return;
           }
+          setCardState(card, true);
+          loadAvatar(assetSource);
+          return;
+        }
 
-          if (type === 'pose') {
+        if (type === 'pose') {
+          const handlePoseToggle = async () => {
             if (locked) {
               return;
             }
@@ -1173,55 +1343,95 @@
               await applyPoseByName(poseName);
               frame(modelGroup);
             }
-            return;
+          };
+
+          if (!locked) {
+            card.addEventListener('click', handlePoseToggle);
+            card.addEventListener('keydown', (event) => {
+              if (event.key === ' ' || event.key === 'Enter') {
+                event.preventDefault();
+                handlePoseToggle();
+              }
+            });
           }
 
-          if (locked) {
-            return;
-          }
-
-          isSelected = !isSelected;
-          setCardState(card, isSelected);
-          if (isSelected) {
-            if (!assetSource) {
-              console.warn(`No asset source registered for card "${cardId}"`);
-              setCardState(card, false);
-              isSelected = false;
-              return;
-            }
-            loadExtra(assetSource, cardId, card);
-          } else {
-            removeExtra(cardId);
-          }
-        };
-
-        if (!locked) {
-          card.addEventListener('click', handleToggle);
-          card.addEventListener('keydown', (event) => {
-            if (event.key === ' ' || event.key === 'Enter') {
-              event.preventDefault();
-              handleToggle();
-            }
-          });
-        }
-
-        if (type === 'avatar') {
-          if (!assetSource) {
-            console.warn(`No asset source registered for avatar card "${cardId}"`);
-            return;
-          }
-          setCardState(card, true);
-          loadAvatar(assetSource);
-        } else if (type === 'pose') {
-          if (card.classList.contains('selected')) {
+          if (initiallySelected) {
             activePoseCard = card;
             activePoseName = poseName;
             applyPoseByName(activePoseName).then(() => {
               frame(modelGroup);
             });
           }
-        } else if (isSelected && assetSource) {
-          loadExtra(assetSource, cardId, card);
+          return;
+        }
+
+        const handleExtraToggle = async () => {
+          const currentlySelected = card.classList.contains('selected');
+
+          if (currentlySelected) {
+            setCardState(card, false);
+            removeExtra(cardId);
+            if (exclusive && slotId) {
+              clearSlotSelection(slotId, cardId);
+              maybeRestoreDefaultSlot(slotId);
+            }
+            return;
+          }
+
+          if (!assetSource) {
+            console.warn(`No asset source registered for card "${cardId}"`);
+            return;
+          }
+
+          if (exclusive && slotId) {
+            enforceSlotExclusivity(slotId, cardId);
+            hideAvatarAttachmentBySlot(slotId);
+          }
+
+          setCardState(card, true);
+          const loaded = await loadExtra(assetSource, cardId, card);
+          if (!loaded) {
+            setCardState(card, false);
+            if (exclusive && slotId) {
+              clearSlotSelection(slotId, cardId);
+              maybeRestoreDefaultSlot(slotId);
+            }
+            return;
+          }
+
+          if (exclusive && slotId) {
+            registerSlotSelection(slotId, { cardId, card, type: 'extra' });
+          }
+        };
+
+        if (!locked) {
+          card.addEventListener('click', handleExtraToggle);
+          card.addEventListener('keydown', (event) => {
+            if (event.key === ' ' || event.key === 'Enter') {
+              event.preventDefault();
+              handleExtraToggle();
+            }
+          });
+        }
+
+        if (initiallySelected && assetSource) {
+          if (exclusive && slotId) {
+            enforceSlotExclusivity(slotId, cardId);
+            hideAvatarAttachmentBySlot(slotId);
+          }
+          loadExtra(assetSource, cardId, card).then((loaded) => {
+            if (!loaded) {
+              setCardState(card, false);
+              if (exclusive && slotId) {
+                clearSlotSelection(slotId, cardId);
+                maybeRestoreDefaultSlot(slotId);
+              }
+              return;
+            }
+            if (exclusive && slotId) {
+              registerSlotSelection(slotId, { cardId, card, type: 'extra' });
+            }
+          });
         }
       });
     }

--- a/index.html
+++ b/index.html
@@ -528,7 +528,7 @@
             <div class="card-body">
               <span class="card-eyebrow">Wardrobe · Base Layer</span>
               <h2 class="card-title">Hero Body Suit</h2>
-              <p class="card-text">Streams the bundled NakedFullBody.glb hero mesh from Assets.zip.</p>
+              <p class="card-text">Streams the NakedFullBody, head, face, eyes, brow, and nose pieces already bundled inside Assets.zip.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
@@ -680,8 +680,19 @@
     const modelGroup = new THREE.Group();
     scene.add(modelGroup);
 
+    const heroBodyPieces = [
+      { key: 'head', source: { zip: 'Assets.zip', entry: 'Assets/Head.001.glb' }, tint: true },
+      { key: 'face', source: { zip: 'Assets.zip', entry: 'Assets/Face.001.glb' }, tint: true },
+      { key: 'eyes', source: { zip: 'Assets.zip', entry: 'Assets/Eyes.001.glb' }, tint: false },
+      { key: 'brows', source: { zip: 'Assets.zip', entry: 'Assets/EyeBrow.001.glb' }, tint: false },
+      { key: 'nose', source: { zip: 'Assets.zip', entry: 'Assets/Nose.001.glb' }, tint: true },
+    ];
+
     let avatar;
+    const avatarAttachments = new Map();
     const extras = new Map();
+    const tintTargets = new Set();
+    let avatarLoadToken = 0;
     const loader = new GLTFLoader();
     const dracoLoader = new DRACOLoader();
     dracoLoader.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/libs/draco/');
@@ -740,6 +751,7 @@
 
     function frame(object) {
       object.position.set(0, 0, 0);
+      object.rotation.set(0, 0, 0);
       object.updateMatrixWorld(true);
       const box = new THREE.Box3().setFromObject(object);
       const size = box.getSize(new THREE.Vector3());
@@ -773,23 +785,62 @@
       });
     }
 
+    function clearAvatarAttachments() {
+      avatarAttachments.forEach((object) => {
+        modelGroup.remove(object);
+      });
+      avatarAttachments.clear();
+    }
+
     function setCardState(card, isSelected) {
       card.classList.toggle('selected', isSelected);
       card.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
     }
 
     async function loadAvatar(source) {
+      const loadToken = ++avatarLoadToken;
       try {
         const gltf = await loadGLTFAsset(source);
+        if (loadToken !== avatarLoadToken) {
+          return;
+        }
         if (avatar) {
           modelGroup.remove(avatar);
         }
+        clearAvatarAttachments();
         avatar = gltf.scene;
         modelGroup.add(avatar);
+
+        tintTargets.clear();
+        tintTargets.add(avatar);
         applyColor(avatar, currentColor);
         frame(modelGroup);
+
+        for (const piece of heroBodyPieces) {
+          try {
+            const attachmentGltf = await loadGLTFAsset(piece.source);
+            if (loadToken !== avatarLoadToken) {
+              return;
+            }
+            const object = attachmentGltf.scene;
+            avatarAttachments.set(piece.key, object);
+            modelGroup.add(object);
+            if (piece.tint) {
+              tintTargets.add(object);
+              applyColor(object, currentColor);
+            }
+          } catch (pieceError) {
+            console.error(`Failed to load core body piece "${piece.key}"`, pieceError);
+          }
+        }
+
+        if (loadToken === avatarLoadToken) {
+          frame(modelGroup);
+        }
       } catch (error) {
-        console.error('Failed to load avatar', error);
+        if (loadToken === avatarLoadToken) {
+          console.error('Failed to load avatar', error);
+        }
       }
     }
 
@@ -875,14 +926,15 @@
 
     function animate() {
       requestAnimationFrame(animate);
-      modelGroup.rotation.y += 0.0045;
       renderer.render(scene, camera);
     }
     animate();
 
     colorInput.addEventListener('input', (event) => {
       currentColor = event.target.value;
-      applyColor(avatar, currentColor);
+      tintTargets.forEach((target) => {
+        applyColor(target, currentColor);
+      });
     });
 
     window.addEventListener('resize', resizeRenderer);

--- a/index.html
+++ b/index.html
@@ -11,20 +11,23 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
   <style>
     :root {
-      --sidebar-bg: rgba(15, 11, 53, 0.55);
-      --sidebar-border: rgba(255, 255, 255, 0.12);
-      --panel-bg: rgba(255, 255, 255, 0.96);
-      --panel-text: #171836;
-      --accent: #6257ff;
-      --accent-dark: #3529ff;
-      --accent-soft: #ebe8ff;
+      --bg-gradient: radial-gradient(120% 120% at 16% 6%, #7d36ff 0%, #3812ab 42%, #0c022d 100%);
+      --sidebar-bg: rgba(17, 9, 68, 0.65);
+      --sidebar-border: rgba(255, 255, 255, 0.14);
+      --panel-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.94) 0%, rgba(237, 234, 255, 0.98) 100%);
+      --panel-border: rgba(138, 124, 255, 0.18);
+      --panel-text: #14153a;
+      --accent: #7f6bff;
+      --accent-dark: #4f34ff;
+      --accent-soft: rgba(129, 116, 255, 0.18);
+      --card-gradient: linear-gradient(160deg, rgba(255, 255, 255, 0.98) 0%, rgba(236, 232, 255, 0.9) 100%);
     }
 
     body {
       margin: 0;
       min-height: 100vh;
       font-family: 'Manrope', sans-serif;
-      background: radial-gradient(circle at top left, #5a1bff 0%, #1f0061 38%, #080020 100%);
+      background: var(--bg-gradient);
       color: #f3f4ff;
     }
 
@@ -43,24 +46,27 @@
     .sidebar {
       width: 88px;
       background: var(--sidebar-bg);
-      backdrop-filter: blur(18px);
+      backdrop-filter: blur(22px);
       border-right: 1px solid var(--sidebar-border);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
       display: flex;
       flex-direction: column;
       align-items: center;
-      padding: 2rem 1rem;
-      gap: 1rem;
+      padding: 2.25rem 1rem;
+      gap: 1.25rem;
     }
 
     .sidebar .logo {
       width: 48px;
       height: 48px;
       border-radius: 16px;
-      background: rgba(255, 255, 255, 0.08);
+      background: linear-gradient(160deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.04) 100%);
+      border: 1px solid rgba(255, 255, 255, 0.18);
       display: grid;
       place-items: center;
       font-weight: 700;
       font-size: 1.125rem;
+      color: #ffffff;
     }
 
     .sidebar .nav-link {
@@ -70,7 +76,7 @@
       display: grid;
       place-items: center;
       color: rgba(255, 255, 255, 0.6);
-      background: transparent;
+      background: rgba(255, 255, 255, 0.02);
       border: 1px solid transparent;
       transition: 0.25s ease;
       font-size: 1.3rem;
@@ -78,21 +84,23 @@
 
     .sidebar .nav-link:hover {
       color: #ffffff;
-      border-color: rgba(255, 255, 255, 0.25);
-      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(255, 255, 255, 0.28);
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow: 0 12px 30px rgba(19, 0, 76, 0.35);
     }
 
     .sidebar .nav-link.active {
-      background: linear-gradient(135deg, #725fff 0%, #4c2fff 100%);
+      background: linear-gradient(140deg, #826bff 0%, #5034ff 100%);
       color: #ffffff;
-      box-shadow: 0 12px 32px rgba(68, 52, 255, 0.45);
+      box-shadow: 0 16px 36px rgba(54, 28, 163, 0.55);
+      border-color: rgba(255, 255, 255, 0.22);
     }
 
     .content-layout {
       flex: 1;
       display: flex;
-      gap: 2.5rem;
-      padding: 2.5rem 3rem;
+      gap: 3rem;
+      padding: 2.75rem 3.25rem;
     }
 
     .customizer-panel {
@@ -100,51 +108,63 @@
       max-width: 520px;
       background: var(--panel-bg);
       color: var(--panel-text);
-      border-radius: 32px;
-      padding: 2.5rem;
-      box-shadow: 0 25px 60px rgba(10, 10, 60, 0.25);
+      border-radius: 36px;
+      padding: 2.75rem;
+      border: 1px solid var(--panel-border);
+      box-shadow: 0 42px 80px rgba(17, 8, 84, 0.28);
       display: flex;
       flex-direction: column;
-      gap: 1.5rem;
+      gap: 1.75rem;
     }
 
     .panel-eyebrow {
       font-size: 0.75rem;
       text-transform: uppercase;
-      letter-spacing: 0.12em;
+      letter-spacing: 0.14em;
       font-weight: 700;
-      color: #8a8bb5;
+      color: #8786c5;
     }
 
     .panel-title {
       font-weight: 700;
       color: var(--panel-text);
+      letter-spacing: -0.01em;
+    }
+
+    .panel-subtext {
+      color: #8b8cb8;
+      font-size: 0.9rem;
     }
 
     .section-tabs {
       display: flex;
-      gap: 0.75rem;
+      gap: 0.5rem;
+      background: rgba(131, 118, 255, 0.16);
+      padding: 0.45rem;
+      border-radius: 999px;
     }
 
     .btn-tab {
+      flex: 1;
       border-radius: 999px !important;
-      border: 1px solid transparent;
-      background: #ececff;
-      color: var(--accent);
+      border: none;
+      background: transparent;
+      color: rgba(79, 52, 255, 0.7);
       font-weight: 600;
-      padding: 0.55rem 1.6rem;
+      padding: 0.55rem 1.5rem;
       box-shadow: none;
       transition: 0.2s ease;
     }
 
     .btn-tab:hover {
-      border-color: rgba(98, 87, 255, 0.35);
+      background: rgba(255, 255, 255, 0.55);
+      color: var(--accent-dark);
     }
 
     .btn-tab.active {
-      background: linear-gradient(135deg, #7365ff 0%, #4331ff 100%);
-      color: #ffffff;
-      box-shadow: 0 12px 32px rgba(68, 52, 255, 0.35);
+      background: #ffffff;
+      color: var(--accent-dark);
+      box-shadow: 0 16px 36px rgba(72, 54, 255, 0.3);
     }
 
     .panel-actions {
@@ -159,19 +179,20 @@
     }
 
     .panel-actions .btn-outline-secondary {
-      border-color: rgba(16, 14, 65, 0.12);
+      border-color: rgba(109, 102, 185, 0.35);
       color: var(--panel-text);
+      background: rgba(255, 255, 255, 0.5);
     }
 
     .panel-actions .btn-outline-secondary:hover {
-      background: rgba(16, 14, 65, 0.08);
+      background: rgba(255, 255, 255, 0.85);
       color: var(--panel-text);
     }
 
     .panel-actions .btn-primary {
-      background: linear-gradient(135deg, #7d6fff 0%, #4c37ff 100%);
+      background: linear-gradient(140deg, #8a76ff 0%, #5237ff 100%);
       border: none;
-      box-shadow: 0 18px 40px rgba(76, 55, 255, 0.35);
+      box-shadow: 0 22px 48px rgba(72, 54, 255, 0.32);
     }
 
     .panel-actions .btn-primary:hover {
@@ -182,6 +203,10 @@
       flex: 1;
       overflow-y: auto;
       padding-right: 0.35rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1.15rem;
+      align-content: start;
     }
 
     .asset-grid::-webkit-scrollbar {
@@ -194,43 +219,97 @@
     }
 
     .asset-card {
-      border: none;
-      border-radius: 24px;
-      background: #f4f5ff;
-      transition: 0.2s ease;
+      position: relative;
+      border: 1px solid rgba(141, 129, 255, 0.2);
+      border-radius: 26px;
+      background: var(--card-gradient);
+      transition: 0.25s ease;
       height: 100%;
-      box-shadow: 0 12px 30px rgba(19, 15, 78, 0.08);
+      box-shadow: 0 18px 46px rgba(22, 15, 70, 0.12);
       cursor: pointer;
+      padding: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
     }
 
-    .asset-card img {
-      border-radius: 20px 20px 12px 12px;
-      object-fit: cover;
+    .asset-card:hover {
+      transform: translateY(-6px);
+      box-shadow: 0 24px 58px rgba(28, 18, 95, 0.18);
+    }
+
+    .asset-card.selected {
+      border-color: rgba(126, 102, 255, 0.65);
+      box-shadow: 0 28px 68px rgba(99, 81, 255, 0.35);
+      background: linear-gradient(160deg, rgba(255, 255, 255, 0.98) 0%, rgba(238, 234, 255, 0.92) 100%);
+    }
+
+    .card-visual {
+      position: relative;
+      border-radius: 20px;
+      overflow: hidden;
+      min-height: 118px;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(135deg, rgba(129, 111, 255, 0.85) 0%, rgba(88, 68, 255, 0.92) 100%);
+      isolation: isolate;
+    }
+
+    .card-visual img {
+      width: 140%;
+      max-width: none;
+      opacity: 0.55;
+      filter: saturate(0) brightness(1.45);
+    }
+
+    .card-visual::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.2) 0%, rgba(118, 93, 255, 0.45) 100%);
+      mix-blend-mode: screen;
+      opacity: 0.65;
+    }
+
+    .card-watermark {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 1.05rem;
+      letter-spacing: 0.45em;
+      text-transform: uppercase;
+      font-weight: 700;
+      color: rgba(255, 255, 255, 0.45);
+      mix-blend-mode: screen;
     }
 
     .asset-card .card-body {
-      padding: 1rem 1.2rem 1.2rem;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+
+    .card-eyebrow {
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      font-weight: 600;
+      color: #8b86dd;
     }
 
     .asset-card .card-title {
-      font-size: 1rem;
+      font-size: 1.05rem;
       font-weight: 600;
-      margin-bottom: 0.25rem;
+      margin-bottom: 0;
+      color: var(--panel-text);
     }
 
     .asset-card .card-text {
       font-size: 0.8rem;
-      color: #7a7ba5;
-    }
-
-    .asset-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 20px 45px rgba(25, 21, 95, 0.16);
-    }
-
-    .asset-card.selected {
-      background: var(--accent-soft);
-      box-shadow: 0 0 0 3px rgba(98, 87, 255, 0.9), 0 24px 48px rgba(66, 55, 255, 0.35);
+      color: #7677a8;
+      margin-bottom: 0;
     }
 
     .viewer-pane {
@@ -242,11 +321,38 @@
     .viewer-wrapper {
       position: relative;
       flex: 1;
-      border-radius: 42px;
-      background: linear-gradient(155deg, #6732ff 0%, #2b0a73 50%, #0a0229 100%);
-      box-shadow: 0 30px 80px rgba(18, 10, 60, 0.65);
+      border-radius: 44px;
+      background: linear-gradient(150deg, #6f3dff 0%, #2c0c79 48%, #070022 100%);
+      border: 1px solid rgba(124, 114, 255, 0.18);
+      box-shadow: 0 48px 120px rgba(14, 6, 70, 0.62);
       overflow: hidden;
       min-height: 520px;
+    }
+
+    .viewer-wrapper::before,
+    .viewer-wrapper::after {
+      content: '';
+      position: absolute;
+      border-radius: 50%;
+      filter: blur(80px);
+      opacity: 0.85;
+      pointer-events: none;
+    }
+
+    .viewer-wrapper::before {
+      width: 60%;
+      height: 60%;
+      top: -22%;
+      right: -10%;
+      background: radial-gradient(circle, rgba(146, 118, 255, 0.9) 0%, rgba(93, 47, 220, 0) 70%);
+    }
+
+    .viewer-wrapper::after {
+      width: 55%;
+      height: 55%;
+      bottom: -18%;
+      left: -12%;
+      background: radial-gradient(circle, rgba(62, 31, 180, 0.8) 0%, rgba(13, 5, 60, 0) 70%);
     }
 
     #viewer {
@@ -258,10 +364,11 @@
       position: absolute;
       top: 28px;
       right: 28px;
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.12);
+      border: 1px solid rgba(255, 255, 255, 0.24);
       border-radius: 20px;
-      padding: 1rem 1.25rem;
-      backdrop-filter: blur(18px);
+      padding: 1rem 1.35rem;
+      backdrop-filter: blur(20px);
       color: #ffffff;
       display: flex;
       flex-direction: column;
@@ -273,7 +380,7 @@
       font-size: 0.75rem;
       text-transform: uppercase;
       letter-spacing: 0.1em;
-      opacity: 0.8;
+      opacity: 0.72;
       font-weight: 600;
     }
 
@@ -352,7 +459,7 @@
           <div>
             <p class="panel-eyebrow mb-1">Outfit</p>
             <h1 class="panel-title h3 mb-0">Asset Library</h1>
-            <p class="text-muted small mb-0">Toggle modular pieces to build the perfect hero look.</p>
+            <p class="panel-subtext mb-0">Toggle modular pieces to build the perfect hero look.</p>
           </div>
           <div class="panel-actions d-none d-md-flex">
             <button type="button" class="btn btn-outline-secondary">Discard</button>
@@ -366,61 +473,71 @@
           <button type="button" class="btn btn-tab">Extras</button>
         </div>
 
-        <div class="asset-grid" role="list">
-          <div id="assetGrid" class="row row-cols-2 row-cols-md-3 g-3">
-            <div class="col">
-              <div class="card asset-card selected" data-url="public/models/Teleporter Base.glb">
-                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Teleporter Base">
-                <div class="card-body">
-                  <h2 class="card-title">Teleporter Base</h2>
-                  <p class="card-text">Foundation platform</p>
-                </div>
-              </div>
+        <div id="assetGrid" class="asset-grid" role="list">
+          <div class="asset-card selected" data-url="public/models/Teleporter Base.glb" role="listitem">
+            <div class="card-visual" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
-            <div class="col">
-              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Arm Cuffs">
-                <div class="card-body">
-                  <h2 class="card-title">Arm Cuffs</h2>
-                  <p class="card-text">Layered accessory</p>
-                </div>
-              </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Platform</span>
+              <h2 class="card-title">Teleporter Base</h2>
+              <p class="card-text">Foundation platform</p>
             </div>
-            <div class="col">
-              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Outer Jacket">
-                <div class="card-body">
-                  <h2 class="card-title">Outer Jacket</h2>
-                  <p class="card-text">Add bold color blocking</p>
-                </div>
-              </div>
+          </div>
+          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+            <div class="card-visual" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
-            <div class="col">
-              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Sneakers">
-                <div class="card-body">
-                  <h2 class="card-title">Sneakers</h2>
-                  <p class="card-text">High-top option</p>
-                </div>
-              </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Accessory</span>
+              <h2 class="card-title">Arm Cuffs</h2>
+              <p class="card-text">Layered accessory</p>
             </div>
-            <div class="col">
-              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Visor">
-                <div class="card-body">
-                  <h2 class="card-title">Visor</h2>
-                  <p class="card-text">Futuristic eyewear</p>
-                </div>
-              </div>
+          </div>
+          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+            <div class="card-visual" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
-            <div class="col">
-              <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
-                <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Backpack">
-                <div class="card-body">
-                  <h2 class="card-title">Backpack</h2>
-                  <p class="card-text">Utility ready</p>
-                </div>
-              </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Outerwear</span>
+              <h2 class="card-title">Outer Jacket</h2>
+              <p class="card-text">Add bold color blocking</p>
+            </div>
+          </div>
+          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+            <div class="card-visual" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
+            </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Footwear</span>
+              <h2 class="card-title">Sneakers</h2>
+              <p class="card-text">High-top option</p>
+            </div>
+          </div>
+          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+            <div class="card-visual" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
+            </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Headgear</span>
+              <h2 class="card-title">Visor</h2>
+              <p class="card-text">Futuristic eyewear</p>
+            </div>
+          </div>
+          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+            <div class="card-visual" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
+            </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Utility</span>
+              <h2 class="card-title">Backpack</h2>
+              <p class="card-text">Utility ready</p>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -1,13 +1,174 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/favicon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Ultimate Character Configurator</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bootstrap Avatar Preview</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+  <style>
+    body { margin: 0; }
+    canvas { width: 100%; height: 100%; display: block; }
+    .sidebar { width: 4rem; }
+    .asset-card { cursor: pointer; }
+    .asset-card.selected { outline: 2px solid #0d6efd; }
+  </style>
+</head>
+<body>
+  <div class="container-fluid">
+    <div class="row">
+      <nav class="sidebar col-auto bg-dark min-vh-100 d-flex flex-column align-items-center py-3 text-white">
+        <button class="btn btn-dark mb-3 active"><i class="bi bi-person"></i></button>
+        <button class="btn btn-dark"><i class="bi bi-tshirt"></i></button>
+      </nav>
+      <main class="col-md-7 py-3">
+        <h1 class="h4 mb-3">Assets</h1>
+        <div id="assetGrid" class="row row-cols-2 row-cols-md-3 g-3">
+          <div class="col">
+            <div class="card asset-card selected" data-url="public/models/Teleporter Base.glb">
+              <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Teleporter Base">
+              <div class="card-body p-2 text-center">
+                <p class="card-text small mb-0">Teleporter Base</p>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+              <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Hair">
+              <div class="card-body p-2 text-center">
+                <p class="card-text small mb-0">Hair</p>
+              </div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="card asset-card" data-url="public/models/Teleporter Base.glb">
+              <img src="public/images/wawasensei-white.png" class="card-img-top" alt="Top">
+              <div class="card-body p-2 text-center">
+                <p class="card-text small mb-0">Top</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+      <aside class="col-md-5 py-3 d-flex flex-column">
+        <div id="viewer" class="border rounded mb-3 flex-grow-1" style="min-height:400px"></div>
+        <div class="mb-3">
+          <label for="colorInput" class="form-label">Body Color</label>
+          <input type="color" class="form-control form-control-color" id="colorInput" value="#ffccaa">
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
+        "three/examples/jsm/loaders/GLTFLoader.js": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/loaders/GLTFLoader.js",
+        "three/examples/jsm/loaders/DRACOLoader.js": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/loaders/DRACOLoader.js"
+      }
+    }
+  </script>
+
+  <script type="module">
+    import * as THREE from 'three';
+    import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+    import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    const viewer = document.getElementById('viewer');
+    renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+    viewer.appendChild(renderer.domElement);
+    camera.aspect = viewer.clientWidth / viewer.clientHeight;
+    camera.updateProjectionMatrix();
+
+    const light = new THREE.HemisphereLight(0xffffff, 0x444444, 1.0);
+    scene.add(light);
+
+    const modelGroup = new THREE.Group();
+    scene.add(modelGroup);
+
+    let avatar;
+    const extras = new Map();
+    const loader = new GLTFLoader();
+    const dracoLoader = new DRACOLoader();
+    dracoLoader.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/libs/draco/');
+    loader.setDRACOLoader(dracoLoader);
+
+    function frame(object) {
+      const box = new THREE.Box3().setFromObject(object);
+      const size = box.getSize(new THREE.Vector3());
+      const center = box.getCenter(new THREE.Vector3());
+      object.position.sub(center);
+      const maxDim = Math.max(size.x, size.y, size.z);
+      const fov = camera.fov * (Math.PI / 180);
+      let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
+      cameraZ *= 1.5;
+      camera.position.set(0, size.y * 0.5, cameraZ);
+      camera.lookAt(0, 0, 0);
+    }
+
+    loader.load('public/models/Armature.glb', (gltf) => {
+      avatar = gltf.scene;
+      modelGroup.add(avatar);
+      frame(modelGroup);
+    }, undefined, (err) => console.error(err));
+
+    function loadExtra(url) {
+      loader.load(url, (gltf) => {
+        const obj = gltf.scene;
+        modelGroup.add(obj);
+        extras.set(url, obj);
+      }, undefined, (err) => console.error(err));
+    }
+
+    function removeExtra(url) {
+      const obj = extras.get(url);
+      if (obj) {
+        modelGroup.remove(obj);
+        extras.delete(url);
+      }
+    }
+
+    document.querySelectorAll('#assetGrid .asset-card').forEach((card) => {
+      const url = card.dataset.url;
+      card.addEventListener('click', () => {
+        card.classList.toggle('selected');
+        if (card.classList.contains('selected')) {
+          loadExtra(url);
+        } else {
+          removeExtra(url);
+        }
+      });
+      if (card.classList.contains('selected')) {
+        loadExtra(url);
+      }
+    });
+
+    function animate() {
+      requestAnimationFrame(animate);
+      modelGroup.rotation.y += 0.005;
+      renderer.render(scene, camera);
+    }
+    animate();
+
+    document.getElementById('colorInput').addEventListener('input', (e) => {
+      if (!avatar) return;
+      avatar.traverse((child) => {
+        if (child.isMesh && child.material && child.material.color) {
+          child.material.color.set(e.target.value);
+        }
+      });
+    });
+
+    window.addEventListener('resize', () => {
+      const { clientWidth, clientHeight } = viewer;
+      renderer.setSize(clientWidth, clientHeight);
+      camera.aspect = clientWidth / clientHeight;
+      camera.updateProjectionMatrix();
+    });
+  </script>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -519,26 +519,54 @@
         </div>
 
         <div id="assetGrid" class="asset-grid" role="list">
-          <div class="asset-card selected locked" data-id="core-hero" data-type="avatar" data-locked="true" data-zip="Assets.zip" data-entry="Assets/NakedFullBody.glb" role="listitem" aria-pressed="true" tabindex="0">
+          <div
+            class="asset-card selected locked"
+            data-id="core-hero"
+            data-type="avatar"
+            data-locked="true"
+            data-zip="Assets.zip"
+            data-entry="Assets/NakedFullBody.glb"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/head.jpg"
+            data-label-active="Pinned in scene"
+            data-label-inactive="Pinned in scene"
+            data-icon-active="bi-pin-angle-fill"
+            data-icon-inactive="bi-pin-angle-fill"
+            role="listitem"
+            aria-pressed="true"
+            tabindex="0"
+          >
             <div class="card-visual" aria-hidden="true">
               <span class="card-badge">Core</span>
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="Hero body thumbnail" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
               <span class="card-eyebrow">Wardrobe · Base Layer</span>
               <h2 class="card-title">Hero Body Suit</h2>
-              <p class="card-text">Streams the NakedFullBody, head, face, eyes, brow, and nose pieces already bundled inside Assets.zip.</p>
+              <p class="card-text">Streams the bundled NakedFullBody mesh together with the matching facial pieces from Assets.zip.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
-              <span>Locked in loadout</span>
+              <span>Pinned in scene</span>
             </div>
           </div>
-          <div class="asset-card selected" data-id="platform-teleporter" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="true" tabindex="0">
+          <div
+            class="asset-card selected"
+            data-id="platform-teleporter"
+            data-url="public/models/Teleporter Base.glb"
+            data-thumb="public/images/wawasensei-white.png"
+            data-label-active="Equipped"
+            data-label-inactive="Tap to equip"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="true"
+            tabindex="0"
+          >
             <div class="card-visual" aria-hidden="true">
               <span class="card-badge">Scene</span>
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="Teleporter base thumbnail" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
@@ -548,71 +576,187 @@
             </div>
             <div class="card-meta">
               <i class="bi bi-check2-circle" aria-hidden="true"></i>
-              <span>Auto loaded</span>
+              <span>Equipped</span>
             </div>
           </div>
-          <div class="asset-card" data-id="wardrobe-cape" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="false" tabindex="0">
+          <div
+            class="asset-card selected"
+            data-id="wardrobe-hair"
+            data-zip="Assets.zip"
+            data-entry="Assets/Hair.010.glb"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/hair.jpg"
+            data-label-active="Equipped"
+            data-label-inactive="Tap to equip"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="true"
+            tabindex="0"
+          >
             <div class="card-visual" aria-hidden="true">
               <span class="card-badge">Wardrobe</span>
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="Hair layer thumbnail" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Shoulders</span>
-              <h2 class="card-title">Holo Cape</h2>
-              <p class="card-text">Dramatic shoulder cape placeholder.</p>
+              <span class="card-eyebrow">Wardrobe · Hair</span>
+              <h2 class="card-title">Layered Hair</h2>
+              <p class="card-text">Loads Hair.010.glb directly from Assets.zip to frame the hero with the bundled style.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-check2-circle" aria-hidden="true"></i>
+              <span>Equipped</span>
+            </div>
+          </div>
+          <div
+            class="asset-card selected"
+            data-id="wardrobe-dress"
+            data-zip="Assets.zip"
+            data-entry="Assets/WawaDress.glb"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/thumbnail_wawadress.png"
+            data-label-active="Equipped"
+            data-label-inactive="Tap to equip"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="true"
+            tabindex="0"
+          >
+            <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Wardrobe</span>
+              <img src="public/images/wawasensei-white.png" alt="Dress thumbnail" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
+            </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Wardrobe · Outfit</span>
+              <h2 class="card-title">Wawa Dress</h2>
+              <p class="card-text">Streams the Draco-compressed WawaDress.glb from Assets.zip for a full-length outfit.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-check2-circle" aria-hidden="true"></i>
+              <span>Equipped</span>
+            </div>
+          </div>
+          <div
+            class="asset-card"
+            data-id="wardrobe-crown"
+            data-zip="Assets.zip"
+            data-entry="Assets/Hat.006.glb"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/thumbnail_crown.png"
+            data-label-active="Equipped"
+            data-label-inactive="Tap to equip"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="false"
+            tabindex="0"
+          >
+            <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Accessory</span>
+              <img src="public/images/wawasensei-white.png" alt="Crown accessory thumbnail" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
+            </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Accessories · Head</span>
+              <h2 class="card-title">Crown Halo</h2>
+              <p class="card-text">Adds the halo crown from Assets/Hat.006.glb for a regal accent.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-plus-circle" aria-hidden="true"></i>
               <span>Tap to equip</span>
             </div>
           </div>
-          <div class="asset-card" data-id="wardrobe-gauntlets" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="false" tabindex="0">
+          <div
+            class="asset-card"
+            data-id="wardrobe-bunny"
+            data-zip="Assets.zip"
+            data-entry="Assets/Hat.007.glb"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/thumbnail_bunny.png"
+            data-label-active="Equipped"
+            data-label-inactive="Tap to equip"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="false"
+            tabindex="0"
+          >
             <div class="card-visual" aria-hidden="true">
-              <span class="card-badge">Wardrobe</span>
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-badge">Accessory</span>
+              <img src="public/images/wawasensei-white.png" alt="Bunny accessory thumbnail" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Arms</span>
-              <h2 class="card-title">Pulse Gauntlets</h2>
-              <p class="card-text">Layered forearm armor accent.</p>
+              <span class="card-eyebrow">Accessories · Head</span>
+              <h2 class="card-title">Bunny Ears</h2>
+              <p class="card-text">Swaps in the playful bunny ear headpiece bundled as Hat.007.glb.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-plus-circle" aria-hidden="true"></i>
               <span>Tap to equip</span>
             </div>
           </div>
-          <div class="asset-card" data-id="wardrobe-boots" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="false" tabindex="0">
+          <div
+            class="asset-card"
+            data-id="wardrobe-shoes"
+            data-zip="Assets.zip"
+            data-entry="Assets/Shoes.002.glb"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/shoes.jpg"
+            data-label-active="Equipped"
+            data-label-inactive="Tap to equip"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="false"
+            tabindex="0"
+          >
             <div class="card-visual" aria-hidden="true">
               <span class="card-badge">Wardrobe</span>
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="Shoes thumbnail" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
               <span class="card-eyebrow">Wardrobe · Footwear</span>
-              <h2 class="card-title">Neon Boots</h2>
-              <p class="card-text">High-grip tactical boot variant.</p>
+              <h2 class="card-title">Strider Boots</h2>
+              <p class="card-text">Loads the stylised boot geometry from Assets/Shoes.002.glb.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-plus-circle" aria-hidden="true"></i>
               <span>Tap to equip</span>
             </div>
           </div>
-          <div class="asset-card" data-id="wardrobe-poses" data-url="public/models/Poses.glb" role="listitem" aria-pressed="false" tabindex="0">
+          <div
+            class="asset-card"
+            data-id="pose-idle"
+            data-type="pose"
+            data-pose="Idle"
+            data-thumb-zip="Assets.zip"
+            data-thumb-entry="Assets/eyes.jpg"
+            data-label-active="Applied"
+            data-label-inactive="Tap to apply"
+            data-icon-active="bi-check2-circle"
+            data-icon-inactive="bi-plus-circle"
+            role="listitem"
+            aria-pressed="false"
+            tabindex="0"
+          >
             <div class="card-visual" aria-hidden="true">
               <span class="card-badge">Pose</span>
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <img src="public/images/wawasensei-white.png" alt="Relaxed pose thumbnail" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Wardrobe · Stance</span>
-              <h2 class="card-title">Pose Pack</h2>
-              <p class="card-text">Toggles the bundled Poses.glb collection.</p>
+              <span class="card-eyebrow">Animation · Pose</span>
+              <h2 class="card-title">Relaxed Idle</h2>
+              <p class="card-text">Applies the Idle clip from the bundled Poses.glb for a relaxed stance.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-plus-circle" aria-hidden="true"></i>
-              <span>Tap to equip</span>
+              <span>Tap to apply</span>
             </div>
           </div>
         </div>
@@ -692,6 +836,11 @@
     const avatarAttachments = new Map();
     const extras = new Map();
     const tintTargets = new Set();
+    const skinnedRoots = new Set();
+    let activePoseName = null;
+    let activePoseCard = null;
+    let poseClipMapPromise = null;
+    const cardThumbnailUrlCache = new Map();
     let avatarLoadToken = 0;
     const loader = new GLTFLoader();
     const dracoLoader = new DRACOLoader();
@@ -749,6 +898,147 @@
       throw new Error('No asset source provided');
     }
 
+    function registerSkinnedRoot(object) {
+      if (!object) return;
+      let hasSkin = false;
+      object.traverse((child) => {
+        if (child.isSkinnedMesh) {
+          hasSkin = true;
+        }
+      });
+      if (hasSkin) {
+        skinnedRoots.add(object);
+      }
+    }
+
+    function unregisterSkinnedRoot(object) {
+      if (!object) return;
+      skinnedRoots.delete(object);
+    }
+
+    function resetSkinnedMeshPose(root) {
+      if (!root) return;
+      root.traverse((child) => {
+        if (child.isSkinnedMesh && child.skeleton) {
+          child.skeleton.pose();
+        }
+      });
+    }
+
+    function resetAllSkinnedMeshesPose() {
+      skinnedRoots.forEach((root) => {
+        resetSkinnedMeshPose(root);
+      });
+    }
+
+    async function ensurePoseClipMap() {
+      if (poseClipMapPromise) {
+        return poseClipMapPromise;
+      }
+      poseClipMapPromise = loadGLTFAsset({ url: 'public/models/Poses.glb' })
+        .then((gltf) => {
+          const clipMap = new Map();
+          (gltf.animations || []).forEach((clip) => {
+            clipMap.set(clip.name, clip);
+          });
+          return clipMap;
+        })
+        .catch((error) => {
+          console.error('Failed to load poses', error);
+          return new Map();
+        });
+      return poseClipMapPromise;
+    }
+
+    async function getPoseClip(poseName) {
+      const clipMap = await ensurePoseClipMap();
+      return clipMap.get(poseName);
+    }
+
+    async function applyPoseByName(poseName) {
+      if (!poseName) {
+        return;
+      }
+      const clip = await getPoseClip(poseName);
+      if (!clip) {
+        console.warn(`Pose "${poseName}" not found in poses set`);
+        return;
+      }
+      skinnedRoots.forEach((root) => {
+        const mixer = new THREE.AnimationMixer(root);
+        const action = mixer.clipAction(clip);
+        action.reset();
+        action.setLoop(THREE.LoopOnce, 0);
+        action.clampWhenFinished = true;
+        action.play();
+        mixer.update(Math.max(clip.duration, 0.0001));
+        mixer.stopAllAction();
+        mixer.uncacheClip(clip);
+        mixer.uncacheRoot(root);
+      });
+    }
+
+    async function reapplyActivePose() {
+      if (activePoseName) {
+        await applyPoseByName(activePoseName);
+      }
+    }
+
+    function clearActivePose() {
+      activePoseName = null;
+      resetAllSkinnedMeshesPose();
+    }
+
+    function getMimeTypeFromFilename(filename) {
+      if (!filename) return 'image/png';
+      const lower = filename.toLowerCase();
+      if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) {
+        return 'image/jpeg';
+      }
+      if (lower.endsWith('.png')) {
+        return 'image/png';
+      }
+      return 'application/octet-stream';
+    }
+
+    function assignThumbnailUrl(card, url, img) {
+      const existing = cardThumbnailUrlCache.get(card);
+      if (existing) {
+        URL.revokeObjectURL(existing);
+      }
+      cardThumbnailUrlCache.set(card, url);
+      img.src = url;
+    }
+
+    async function loadCardThumbnail(card) {
+      const img = card.querySelector('.card-visual img');
+      if (!img) {
+        return;
+      }
+      const thumbZip = card.dataset.thumbZip;
+      const thumbEntry = card.dataset.thumbEntry;
+      const thumbUrl = card.dataset.thumb;
+      if (thumbZip && thumbEntry) {
+        try {
+          const buffer = await getZipEntryBuffer(thumbZip, thumbEntry);
+          const blob = new Blob([buffer], { type: getMimeTypeFromFilename(thumbEntry) });
+          const objectUrl = URL.createObjectURL(blob);
+          assignThumbnailUrl(card, objectUrl, img);
+        } catch (error) {
+          console.error(`Failed to load thumbnail "${thumbEntry}" from ${thumbZip}`, error);
+        }
+        return;
+      }
+      if (thumbUrl) {
+        img.src = thumbUrl;
+      }
+    }
+
+    window.addEventListener('beforeunload', () => {
+      cardThumbnailUrlCache.forEach((url) => URL.revokeObjectURL(url));
+      cardThumbnailUrlCache.clear();
+    });
+
     function frame(object) {
       object.position.set(0, 0, 0);
       object.rotation.set(0, 0, 0);
@@ -788,6 +1078,7 @@
     function clearAvatarAttachments() {
       avatarAttachments.forEach((object) => {
         modelGroup.remove(object);
+        unregisterSkinnedRoot(object);
       });
       avatarAttachments.clear();
     }
@@ -795,6 +1086,27 @@
     function setCardState(card, isSelected) {
       card.classList.toggle('selected', isSelected);
       card.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+      const meta = card.querySelector('.card-meta');
+      if (meta) {
+        const icon = meta.querySelector('i');
+        const label = meta.querySelector('span');
+        const activeText = card.dataset.labelActive || meta.dataset.labelActive;
+        const inactiveText = card.dataset.labelInactive || meta.dataset.labelInactive;
+        const activeIcon = card.dataset.iconActive || meta.dataset.iconActive;
+        const inactiveIcon = card.dataset.iconInactive || meta.dataset.iconInactive;
+        if (label) {
+          const text = isSelected ? activeText : inactiveText;
+          if (text) {
+            label.textContent = text;
+          }
+        }
+        if (icon) {
+          const iconClass = isSelected ? activeIcon : inactiveIcon;
+          if (iconClass) {
+            icon.className = `bi ${iconClass}`;
+          }
+        }
+      }
     }
 
     async function loadAvatar(source) {
@@ -805,16 +1117,16 @@
           return;
         }
         if (avatar) {
+          unregisterSkinnedRoot(avatar);
           modelGroup.remove(avatar);
         }
         clearAvatarAttachments();
         avatar = gltf.scene;
         modelGroup.add(avatar);
-
+        registerSkinnedRoot(avatar);
         tintTargets.clear();
         tintTargets.add(avatar);
         applyColor(avatar, currentColor);
-        frame(modelGroup);
 
         for (const piece of heroBodyPieces) {
           try {
@@ -825,6 +1137,7 @@
             const object = attachmentGltf.scene;
             avatarAttachments.set(piece.key, object);
             modelGroup.add(object);
+            registerSkinnedRoot(object);
             if (piece.tint) {
               tintTargets.add(object);
               applyColor(object, currentColor);
@@ -835,6 +1148,11 @@
         }
 
         if (loadToken === avatarLoadToken) {
+          if (activePoseName) {
+            await reapplyActivePose();
+          } else {
+            resetAllSkinnedMeshesPose();
+          }
           frame(modelGroup);
         }
       } catch (error) {
@@ -856,6 +1174,10 @@
         const obj = gltf.scene;
         extras.set(key, obj);
         modelGroup.add(obj);
+        registerSkinnedRoot(obj);
+        if (activePoseName) {
+          await applyPoseByName(activePoseName);
+        }
         frame(modelGroup);
       } catch (error) {
         console.error(`Failed to load asset "${key}"`, error);
@@ -867,6 +1189,12 @@
       if (obj) {
         modelGroup.remove(obj);
         extras.delete(key);
+        unregisterSkinnedRoot(obj);
+        if (activePoseName) {
+          reapplyActivePose();
+        } else {
+          resetAllSkinnedMeshesPose();
+        }
         frame(modelGroup);
       }
     }
@@ -885,13 +1213,37 @@
       const locked = card.dataset.locked === 'true';
       let isSelected = card.classList.contains('selected');
 
+      loadCardThumbnail(card);
       setCardState(card, isSelected);
 
-      const handleToggle = () => {
+      const handleToggle = async () => {
         if (type === 'avatar') {
           isSelected = true;
           setCardState(card, true);
-          loadAvatar(assetSource);
+          await loadAvatar(assetSource);
+          return;
+        }
+
+        if (type === 'pose') {
+          if (locked) {
+            return;
+          }
+          const poseName = card.dataset.pose || cardId;
+          if (activePoseCard === card) {
+            setCardState(card, false);
+            activePoseCard = null;
+            clearActivePose();
+            frame(modelGroup);
+          } else {
+            if (activePoseCard) {
+              setCardState(activePoseCard, false);
+            }
+            activePoseCard = card;
+            activePoseName = poseName;
+            setCardState(card, true);
+            await applyPoseByName(poseName);
+            frame(modelGroup);
+          }
           return;
         }
 
@@ -919,6 +1271,14 @@
       if (type === 'avatar') {
         setCardState(card, true);
         loadAvatar(assetSource);
+      } else if (type === 'pose') {
+        if (card.classList.contains('selected')) {
+          activePoseCard = card;
+          activePoseName = card.dataset.pose || cardId;
+          applyPoseByName(activePoseName).then(() => {
+            frame(modelGroup);
+          });
+        }
       } else if (isSelected) {
         loadExtra(assetSource, cardId, card);
       }

--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@
         </div>
 
         <div id="assetGrid" class="asset-grid" role="list">
-          <div class="asset-card selected locked" data-id="core-hero" data-url="public/models/Armature.glb" data-type="avatar" data-locked="true" role="listitem" aria-pressed="true" tabindex="0">
+          <div class="asset-card selected locked" data-id="core-hero" data-type="avatar" data-locked="true" data-zip="Assets.zip" data-entry="Assets/NakedFullBody.glb" role="listitem" aria-pressed="true" tabindex="0">
             <div class="card-visual" aria-hidden="true">
               <span class="card-badge">Core</span>
               <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
@@ -528,7 +528,7 @@
             <div class="card-body">
               <span class="card-eyebrow">Wardrobe · Base Layer</span>
               <h2 class="card-title">Hero Body Suit</h2>
-              <p class="card-text">Loads the bundled Armature.glb hero mesh.</p>
+              <p class="card-text">Streams the bundled NakedFullBody.glb hero mesh from Assets.zip.</p>
             </div>
             <div class="card-meta">
               <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
@@ -640,6 +640,7 @@
     }
   </script>
 
+  <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
   <script type="module">
     import * as THREE from 'three';
     import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -649,6 +650,7 @@
     const camera = new THREE.PerspectiveCamera(60, 1, 0.1, 100);
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
     renderer.setPixelRatio(window.devicePixelRatio);
+    const JSZipLib = window.JSZip;
 
     const viewerWrapper = document.getElementById('viewerWrapper');
     const viewer = document.getElementById('viewer');
@@ -684,6 +686,57 @@
     const dracoLoader = new DRACOLoader();
     dracoLoader.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/libs/draco/');
     loader.setDRACOLoader(dracoLoader);
+
+    const zipFileCache = new Map();
+    const zipEntryCache = new Map();
+
+    async function getZipFile(zipPath) {
+      if (zipFileCache.has(zipPath)) {
+        return zipFileCache.get(zipPath);
+      }
+      const response = await fetch(zipPath);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch ${zipPath}: ${response.status} ${response.statusText}`);
+      }
+      if (!JSZipLib) {
+        throw new Error('JSZip failed to load');
+      }
+      const buffer = await response.arrayBuffer();
+      const zip = await JSZipLib.loadAsync(buffer);
+      zipFileCache.set(zipPath, zip);
+      return zip;
+    }
+
+    async function getZipEntryBuffer(zipPath, entryPath) {
+      const cacheKey = `${zipPath}::${entryPath}`;
+      if (zipEntryCache.has(cacheKey)) {
+        return zipEntryCache.get(cacheKey);
+      }
+      const zip = await getZipFile(zipPath);
+      const entry = zip.file(entryPath);
+      if (!entry) {
+        throw new Error(`Entry "${entryPath}" not found in ${zipPath}`);
+      }
+      const arrayBuffer = await entry.async('arraybuffer');
+      zipEntryCache.set(cacheKey, arrayBuffer);
+      return arrayBuffer;
+    }
+
+    async function loadGLTFAsset(source) {
+      const { url, zip, entry } = source;
+      if (zip && entry) {
+        const buffer = await getZipEntryBuffer(zip, entry);
+        return new Promise((resolve, reject) => {
+          loader.parse(buffer, '', resolve, reject);
+        });
+      }
+      if (url) {
+        return new Promise((resolve, reject) => {
+          loader.load(url, resolve, undefined, reject);
+        });
+      }
+      throw new Error('No asset source provided');
+    }
 
     function frame(object) {
       object.position.set(0, 0, 0);
@@ -725,8 +778,9 @@
       card.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
     }
 
-    function loadAvatar(url) {
-      loader.load(url, (gltf) => {
+    async function loadAvatar(source) {
+      try {
+        const gltf = await loadGLTFAsset(source);
         if (avatar) {
           modelGroup.remove(avatar);
         }
@@ -734,14 +788,17 @@
         modelGroup.add(avatar);
         applyColor(avatar, currentColor);
         frame(modelGroup);
-      }, undefined, (err) => console.error(err));
+      } catch (error) {
+        console.error('Failed to load avatar', error);
+      }
     }
 
-    function loadExtra(url, key, card) {
+    async function loadExtra(source, key, card) {
       if (extras.has(key)) {
         return;
       }
-      loader.load(url, (gltf) => {
+      try {
+        const gltf = await loadGLTFAsset(source);
         if (!card.classList.contains('selected')) {
           return;
         }
@@ -749,7 +806,9 @@
         extras.set(key, obj);
         modelGroup.add(obj);
         frame(modelGroup);
-      }, undefined, (err) => console.error(err));
+      } catch (error) {
+        console.error(`Failed to load asset "${key}"`, error);
+      }
     }
 
     function removeExtra(key) {
@@ -765,8 +824,12 @@
     let currentColor = colorInput.value;
 
     document.querySelectorAll('#assetGrid .asset-card').forEach((card) => {
-      const url = card.dataset.url;
-      const cardId = card.dataset.id || url;
+      const assetSource = {
+        url: card.dataset.url || undefined,
+        zip: card.dataset.zip || undefined,
+        entry: card.dataset.entry || undefined,
+      };
+      const cardId = card.dataset.id || card.dataset.entry || card.dataset.url;
       const type = card.dataset.type || 'extra';
       const locked = card.dataset.locked === 'true';
       let isSelected = card.classList.contains('selected');
@@ -777,7 +840,7 @@
         if (type === 'avatar') {
           isSelected = true;
           setCardState(card, true);
-          loadAvatar(url);
+          loadAvatar(assetSource);
           return;
         }
 
@@ -788,7 +851,7 @@
         isSelected = !isSelected;
         setCardState(card, isSelected);
         if (isSelected) {
-          loadExtra(url, cardId, card);
+          loadExtra(assetSource, cardId, card);
         } else {
           removeExtra(cardId);
         }
@@ -804,9 +867,9 @@
 
       if (type === 'avatar') {
         setCardState(card, true);
-        loadAvatar(url);
+        loadAvatar(assetSource);
       } else if (isSelected) {
-        loadExtra(url, cardId, card);
+        loadExtra(assetSource, cardId, card);
       }
     });
 

--- a/index.html
+++ b/index.html
@@ -312,6 +312,51 @@
       margin-bottom: 0;
     }
 
+    .asset-card.locked {
+      cursor: default;
+    }
+
+    .asset-card.locked:hover {
+      transform: none;
+      box-shadow: 0 18px 46px rgba(22, 15, 70, 0.12);
+    }
+
+    .card-visual .card-badge {
+      position: absolute;
+      top: 14px;
+      left: 16px;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      font-size: 0.62rem;
+      font-weight: 700;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      background: rgba(255, 255, 255, 0.28);
+      color: rgba(20, 16, 78, 0.78);
+    }
+
+    .asset-card.locked .card-badge {
+      background: rgba(18, 13, 68, 0.7);
+      color: #f4f3ff;
+    }
+
+    .card-meta {
+      margin-top: auto;
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #7a74bb;
+      font-weight: 600;
+    }
+
+    .card-meta .bi {
+      font-size: 0.85rem;
+      color: #9084ff;
+    }
+
     .viewer-pane {
       flex: 1;
       display: flex;
@@ -474,70 +519,100 @@
         </div>
 
         <div id="assetGrid" class="asset-grid" role="list">
-          <div class="asset-card selected" data-url="public/models/Teleporter Base.glb" role="listitem">
+          <div class="asset-card selected locked" data-id="core-hero" data-url="public/models/Armature.glb" data-type="avatar" data-locked="true" role="listitem" aria-pressed="true" tabindex="0">
             <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Core</span>
               <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Platform</span>
+              <span class="card-eyebrow">Wardrobe · Base Layer</span>
+              <h2 class="card-title">Hero Body Suit</h2>
+              <p class="card-text">Loads the bundled Armature.glb hero mesh.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-pin-angle-fill" aria-hidden="true"></i>
+              <span>Locked in loadout</span>
+            </div>
+          </div>
+          <div class="asset-card selected" data-id="platform-teleporter" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="true" tabindex="0">
+            <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Scene</span>
+              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
+              <span class="card-watermark" aria-hidden="true">SENSEI</span>
+            </div>
+            <div class="card-body">
+              <span class="card-eyebrow">Environment · Platform</span>
               <h2 class="card-title">Teleporter Base</h2>
-              <p class="card-text">Foundation platform</p>
+              <p class="card-text">Supplied pedestal from the original scene kit.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-check2-circle" aria-hidden="true"></i>
+              <span>Auto loaded</span>
             </div>
           </div>
-          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+          <div class="asset-card" data-id="wardrobe-cape" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="false" tabindex="0">
             <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Wardrobe</span>
               <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Accessory</span>
-              <h2 class="card-title">Arm Cuffs</h2>
-              <p class="card-text">Layered accessory</p>
+              <span class="card-eyebrow">Wardrobe · Shoulders</span>
+              <h2 class="card-title">Holo Cape</h2>
+              <p class="card-text">Dramatic shoulder cape placeholder.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-plus-circle" aria-hidden="true"></i>
+              <span>Tap to equip</span>
             </div>
           </div>
-          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+          <div class="asset-card" data-id="wardrobe-gauntlets" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="false" tabindex="0">
             <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Wardrobe</span>
               <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Outerwear</span>
-              <h2 class="card-title">Outer Jacket</h2>
-              <p class="card-text">Add bold color blocking</p>
+              <span class="card-eyebrow">Wardrobe · Arms</span>
+              <h2 class="card-title">Pulse Gauntlets</h2>
+              <p class="card-text">Layered forearm armor accent.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-plus-circle" aria-hidden="true"></i>
+              <span>Tap to equip</span>
             </div>
           </div>
-          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+          <div class="asset-card" data-id="wardrobe-boots" data-url="public/models/Teleporter Base.glb" role="listitem" aria-pressed="false" tabindex="0">
             <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Wardrobe</span>
               <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Footwear</span>
-              <h2 class="card-title">Sneakers</h2>
-              <p class="card-text">High-top option</p>
+              <span class="card-eyebrow">Wardrobe · Footwear</span>
+              <h2 class="card-title">Neon Boots</h2>
+              <p class="card-text">High-grip tactical boot variant.</p>
+            </div>
+            <div class="card-meta">
+              <i class="bi bi-plus-circle" aria-hidden="true"></i>
+              <span>Tap to equip</span>
             </div>
           </div>
-          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
+          <div class="asset-card" data-id="wardrobe-poses" data-url="public/models/Poses.glb" role="listitem" aria-pressed="false" tabindex="0">
             <div class="card-visual" aria-hidden="true">
+              <span class="card-badge">Pose</span>
               <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
               <span class="card-watermark" aria-hidden="true">SENSEI</span>
             </div>
             <div class="card-body">
-              <span class="card-eyebrow">Headgear</span>
-              <h2 class="card-title">Visor</h2>
-              <p class="card-text">Futuristic eyewear</p>
+              <span class="card-eyebrow">Wardrobe · Stance</span>
+              <h2 class="card-title">Pose Pack</h2>
+              <p class="card-text">Toggles the bundled Poses.glb collection.</p>
             </div>
-          </div>
-          <div class="asset-card" data-url="public/models/Teleporter Base.glb" role="listitem">
-            <div class="card-visual" aria-hidden="true">
-              <img src="public/images/wawasensei-white.png" alt="" aria-hidden="true">
-              <span class="card-watermark" aria-hidden="true">SENSEI</span>
-            </div>
-            <div class="card-body">
-              <span class="card-eyebrow">Utility</span>
-              <h2 class="card-title">Backpack</h2>
-              <p class="card-text">Utility ready</p>
+            <div class="card-meta">
+              <i class="bi bi-plus-circle" aria-hidden="true"></i>
+              <span>Tap to equip</span>
             </div>
           </div>
         </div>
@@ -611,10 +686,15 @@
     loader.setDRACOLoader(dracoLoader);
 
     function frame(object) {
+      object.position.set(0, 0, 0);
+      object.updateMatrixWorld(true);
       const box = new THREE.Box3().setFromObject(object);
       const size = box.getSize(new THREE.Vector3());
+      if (size.lengthSq() === 0) {
+        return;
+      }
       const center = box.getCenter(new THREE.Vector3());
-      object.position.sub(center);
+      object.position.set(-center.x, -center.y, -center.z);
       const maxDim = Math.max(size.x, size.y, size.z);
       const fov = camera.fov * (Math.PI / 180);
       let cameraZ = Math.abs(maxDim / 2 / Math.tan(fov / 2));
@@ -623,40 +703,110 @@
       camera.lookAt(0, 0.6, 0);
     }
 
-    loader.load('public/models/Armature.glb', (gltf) => {
-      avatar = gltf.scene;
-      modelGroup.add(avatar);
-      frame(modelGroup);
-    }, undefined, (err) => console.error(err));
+    function applyColor(target, color) {
+      if (!target) return;
+      target.traverse((child) => {
+        if (child.isMesh && child.material) {
+          if (Array.isArray(child.material)) {
+            child.material.forEach((material) => {
+              if (material && material.color) {
+                material.color.set(color);
+              }
+            });
+          } else if (child.material.color) {
+            child.material.color.set(color);
+          }
+        }
+      });
+    }
 
-    function loadExtra(url) {
+    function setCardState(card, isSelected) {
+      card.classList.toggle('selected', isSelected);
+      card.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+    }
+
+    function loadAvatar(url) {
       loader.load(url, (gltf) => {
-        const obj = gltf.scene;
-        modelGroup.add(obj);
-        extras.set(url, obj);
+        if (avatar) {
+          modelGroup.remove(avatar);
+        }
+        avatar = gltf.scene;
+        modelGroup.add(avatar);
+        applyColor(avatar, currentColor);
+        frame(modelGroup);
       }, undefined, (err) => console.error(err));
     }
 
-    function removeExtra(url) {
-      const obj = extras.get(url);
+    function loadExtra(url, key, card) {
+      if (extras.has(key)) {
+        return;
+      }
+      loader.load(url, (gltf) => {
+        if (!card.classList.contains('selected')) {
+          return;
+        }
+        const obj = gltf.scene;
+        extras.set(key, obj);
+        modelGroup.add(obj);
+        frame(modelGroup);
+      }, undefined, (err) => console.error(err));
+    }
+
+    function removeExtra(key) {
+      const obj = extras.get(key);
       if (obj) {
         modelGroup.remove(obj);
-        extras.delete(url);
+        extras.delete(key);
+        frame(modelGroup);
       }
     }
 
+    const colorInput = document.getElementById('colorInput');
+    let currentColor = colorInput.value;
+
     document.querySelectorAll('#assetGrid .asset-card').forEach((card) => {
       const url = card.dataset.url;
-      card.addEventListener('click', () => {
-        card.classList.toggle('selected');
-        if (card.classList.contains('selected')) {
-          loadExtra(url);
+      const cardId = card.dataset.id || url;
+      const type = card.dataset.type || 'extra';
+      const locked = card.dataset.locked === 'true';
+      let isSelected = card.classList.contains('selected');
+
+      setCardState(card, isSelected);
+
+      const handleToggle = () => {
+        if (type === 'avatar') {
+          isSelected = true;
+          setCardState(card, true);
+          loadAvatar(url);
+          return;
+        }
+
+        if (locked) {
+          return;
+        }
+
+        isSelected = !isSelected;
+        setCardState(card, isSelected);
+        if (isSelected) {
+          loadExtra(url, cardId, card);
         } else {
-          removeExtra(url);
+          removeExtra(cardId);
+        }
+      };
+
+      card.addEventListener('click', handleToggle);
+      card.addEventListener('keydown', (event) => {
+        if (event.key === ' ' || event.key === 'Enter') {
+          event.preventDefault();
+          handleToggle();
         }
       });
-      if (card.classList.contains('selected')) {
-        loadExtra(url);
+
+      if (type === 'avatar') {
+        setCardState(card, true);
+        loadAvatar(url);
+      } else if (isSelected) {
+        loadExtra(url, cardId, card);
       }
     });
 
@@ -667,13 +817,9 @@
     }
     animate();
 
-    document.getElementById('colorInput').addEventListener('input', (event) => {
-      if (!avatar) return;
-      avatar.traverse((child) => {
-        if (child.isMesh && child.material && child.material.color) {
-          child.material.color.set(event.target.value);
-        }
-      });
+    colorInput.addEventListener('input', (event) => {
+      currentColor = event.target.value;
+      applyColor(avatar, currentColor);
     });
 
     window.addEventListener('resize', resizeRenderer);

--- a/index.html
+++ b/index.html
@@ -115,6 +115,8 @@
       display: flex;
       flex-direction: column;
       gap: 1.75rem;
+      max-height: calc(100vh - 5.5rem);
+      overflow: hidden;
     }
 
     .panel-eyebrow {
@@ -201,6 +203,7 @@
 
     .asset-grid {
       flex: 1;
+      min-height: 0;
       overflow-y: auto;
       padding-right: 0.35rem;
       display: grid;
@@ -360,18 +363,19 @@
     .viewer-pane {
       flex: 1;
       display: flex;
-      align-items: stretch;
+      align-items: center;
+      justify-content: center;
     }
 
     .viewer-wrapper {
       position: relative;
-      flex: 1;
+      width: min(100%, 560px);
+      height: clamp(360px, 68vh, 640px);
       border-radius: 44px;
       background: linear-gradient(150deg, #6f3dff 0%, #2c0c79 48%, #070022 100%);
       border: 1px solid rgba(124, 114, 255, 0.18);
       box-shadow: 0 48px 120px rgba(14, 6, 70, 0.62);
       overflow: hidden;
-      min-height: 520px;
     }
 
     .viewer-wrapper::before,
@@ -466,10 +470,13 @@
 
       .customizer-panel {
         max-width: none;
+        max-height: none;
+        overflow: visible;
       }
 
       .viewer-wrapper {
-        min-height: 420px;
+        width: 100%;
+        height: clamp(320px, 60vh, 560px);
       }
     }
 


### PR DESCRIPTION
## Summary
- display assets in a selectable card grid with left sidebar and viewer
- load or remove extra models when asset cards are toggled
- document the grid-based avatar editor layout
- use bundled wawasensei-white.png for asset thumbnails
- reuse Teleporter Base model for all cards to avoid adding binary assets

## Testing
- `node node_modules/vite/bin/vite.js build`


------
https://chatgpt.com/codex/tasks/task_e_68c76a1c6dd48324b52142ed3ac2dd7f